### PR TITLE
Switch order in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn "app:create_app()"
 release: flask db upgrade
+web: gunicorn "app:create_app()"


### PR DESCRIPTION
Something weird happened where the release dyno was the only one I was allowed to have running. I've switched them round in the hope that future deployments don't end up kaput like before