### PR TITLE
Write Grade initialisation correctly

### DIFF
--- a/modules/seed.py
+++ b/modules/seed.py
@@ -22,7 +22,7 @@ def generate_random_fixed_data():
                  "South West England", "Wales", "West Midlands", "Yorkshire & the Humber"]
 
     organisations = [Organisation(name=string) for string in organisations]
-    grades = [Grade(value=string, rank=i) for string, i in enumerate(grades)]
+    grades = [Grade(value=string, rank=i) for i, string in enumerate(grades)]
     professions = [Profession(value=string) for string in professions]
     locations = [Location(value=string) for string in locations]
 


### PR DESCRIPTION
The deployment failed because I was generating a Grade object with a value of "i" and a rank of "Grade {i}" because I temporarily forgot how enumerate works.

What's really throwing me is that I feel like the test should have pointed this out...