### PR TITLE
Look for secret key in env

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ import os
 def create_app():
     app = Flask(__name__)
     app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL')
-    app.secret_key = secrets.token_urlsafe(64)
+    app.secret_key = os.environ.get('SECRET_KEY') or secrets.token_urlsafe(64)
 
     from app.models import db, login_manager, migrate
     db.init_app(app)


### PR DESCRIPTION
Heroku runs multiple workers, ie versions of the Flask web server. As it stands, each worker gets its own secret key. That means it thinks all the other workers are malicious.

This is less than ideal, because it logs the user out every time they make a get request.

I can solve this by scaling down the workers to 1, or by using one secret key. I'm doing the latter with this approach