### PR TITLE
Make new role grades include one under

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -79,16 +79,18 @@ class Grade(db.Model):
         return eligible_grades
 
     @staticmethod
-    def promotion_roles(current_grade: 'Grade'):
+    def new_grades(current_grade: 'Grade'):
         """
-        Grades that are equal to, or more senior than, `current_grade`
+        Grades that are one below, equal to, or more senior than, `current_grade`. We include grades one below because
+        candidates may be coming off temporary promotion. Remember that the more senior the role, the lower the rank
+        value!
         :param current_grade: Grade object, describing the current Grade of Candidate
         :type current_grade: Grade
         :return: A list of grades more senior or at the same level
         :rtype: List[Grade]
         """
         current_rank = current_grade.rank
-        return Grade.query.filter(Grade.rank <= current_rank).order_by(Grade.rank.asc()).all()
+        return Grade.query.filter(Grade.rank <= (current_rank + 1)).order_by(Grade.rank.asc()).all()
 
 
 class Profession(db.Model):

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -66,7 +66,7 @@ def update(bulk_or_single, update_type, candidate_id=None):
         db.session.commit()
         return redirect(url_for('route_blueprint.complete'))
     update_types = {
-        "role": {'title': "Role update", "promotable_grades": Grade.promotion_roles(Grade(value='Grade name', rank=7)),
+        "role": {'title': "Role update", "promotable_grades": Grade.new_grades(Grade(value='Grade name', rank=7)),
                  "organisations": Organisation.query.all(), "locations": Location.query.all(),
                  "professions": Profession.query.all()
                  },

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -44,19 +44,13 @@ class TestGrade:
         assert ['Grade 7', 'Grade 6'] == [grade.value for grade in Grade.eligible('FLS')]
         assert ['Deputy Director (SCS1)'] == [grade.value for grade in Grade.eligible('SLS')]
 
-    def test_promotions_returns_correct_grades(self, test_database, test_grades):
+    def test_new_grades_returns_correct_grades(self, test_database, test_grades):
         current_grade = Grade(value='One below SCS', rank=5)
-        promotion_roles = set([grade.value for grade in Grade.promotion_roles(current_grade)])
-        assert {'Grade 6', 'Deputy Director (SCS1)'} == promotion_roles
+        promotion_roles = set([grade.value for grade in Grade.new_grades(current_grade)])
+        assert promotion_roles == {'Grade 7', 'Grade 6', 'Deputy Director (SCS1)'}
         assert 'Admin Assistant (AA)' not in promotion_roles
 
-    def test_promotions_returns_grades_in_rank_order(self, test_database, test_grades):
+    def test_new_grades_returns_grades_in_rank_order(self, test_database, test_grades):
         current_grade = Grade(value='One below SCS', rank=5)
-        promotion_roles = [grade.value for grade in Grade.promotion_roles(current_grade)]
-        assert ['Grade 6', 'Deputy Director (SCS1)'] == promotion_roles
-        assert 'Admin Assistant (AA)' not in promotion_roles
-
-    def test_promotions_returns_grades_in_rank_order(self, test_database, test_grades):
-        current_grade = Grade(value='One below SCS', rank=5)
-        promotion_roles = [grade.value for grade in Grade.promotion_roles(current_grade)]
-        assert ['Deputy Director (SCS1)', 'Grade 6'] == promotion_roles
+        promotion_roles = [grade.value for grade in Grade.new_grades(current_grade)]
+        assert promotion_roles == ['Deputy Director (SCS1)', 'Grade 6', 'Grade 7']


### PR DESCRIPTION
An edge case I discovered when testing with users is that there has to be a mechanism for recording when a candidate came off temporary promotion. Previously the system could not handle this demotion, but thankfully now it can.