### PR TITLE
Add TP option

### DIFF
--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -61,7 +61,7 @@ def update(bulk_or_single, update_type, candidate_id=None):
             ),
             organisation_id=form_dict.get('new-org'), candidate_id=candidate.id,
             profession_id=form_dict.get('new-profession'), location_id=form_dict.get('new-location'),
-            grade_id=form_dict.get('new-grade')
+            grade_id=form_dict.get('new-grade'), temporary_promotion=bool(form_dict.get('temporary-promotion'))
         ))
         db.session.commit()
         return redirect(url_for('route_blueprint.complete'))

--- a/app/templates/updates/single-role.html
+++ b/app/templates/updates/single-role.html
@@ -1,14 +1,12 @@
 {% extends 'layout.html' %}
 
 {% block content %}
+
+    <h2 class="govuk-heading-l">
+        Details of the new role for {{ candidate.personal_email }}
+    </h2>
     <form class="form" action="" method="post">
         <div class="govuk-form-group">
-            <legend class="govuk-fieldset__legend--m">
-                <h2 class="govuk-fieldset__heading">
-                    Details of the new role for {{ candidate.personal_email }}
-                </h2>
-            </legend>
-
             <label class="govuk-label" for="new-grade">
                 New grade
             </label>
@@ -17,8 +15,30 @@
                 <option value={{ grade.id }}>{{ grade.value }}</option>
               {% endfor %}
           </select>
-            <br>
-            <br>
+        </div>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" aria-describedby="temporary-promotion-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                Is this a temporary promotion?
+            </legend>
+            <span id="temporary-promotion-hint" class="govuk-hint">
+              Temporary promotion is also known as TP, or getting 'TDA' - temporary duties allowance
+            </span>
+            <div class="govuk-radios govuk-radios--inline">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="temporary-promotion-1" name="temporary-promotion" type="radio" value="1">
+                <label class="govuk-label govuk-radios__label" for="temporary-promotion-1">
+                  Yes
+                </label> </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="temporary-promotion-2" name="temporary-promotion" type="radio" value="0" checked>
+                <label class="govuk-label govuk-radios__label" for="temporary-promotion-2">
+                  No
+                </label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
             <div class="govuk-form-group">
               <fieldset class="govuk-fieldset" aria-describedby="start-date-hint" role="group">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
@@ -90,8 +110,6 @@
                   {% endfor %}
               </select>
             </div>
-
-        </div>
 
         <div class="input submit">
             <input type="submit" value="Continue" class="govuk-button">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -37,12 +37,13 @@ class TestSingleUpdate:
         data = {
             'new-grade': higher_grade.id, 'start-date-day': '1', 'start-date-month': '1', 'start-date-year': '2019',
             'new-org': str(new_org.id), 'new-profession': str(new_profession.id),
-            'new-location': str(new_location.id),
+            'new-location': str(new_location.id), 'temporary-promotion': '1'
         }
         test_client.post('/update/single/role/1', data=data)
         saved_role = Role.query.first()
         assert saved_role.date_started == date(2019, 1, 1)
         assert saved_role.candidate_id == test_candidate.id
+        assert saved_role.temporary_promotion
 
 
 class TestSearchCandidate:


### PR DESCRIPTION
When adding a new role, a user can select "Temporary Promotion" for those candidates who aren't confirmed in their new grade. New interface:
<img width="862" alt="Screen Shot 2019-06-04 at 10 02 58" src="https://user-images.githubusercontent.com/3410350/58866271-26830e80-86b0-11e9-9334-ee563a98763d.png">

The checkbox defaults to "No"