### PR TITLE
[HOTFIX]Promotions should only be susbstantive

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -59,7 +59,7 @@ class Candidate(db.Model):
     def __repr__(self):
         return f'<Candidate email {self.email_address}>'
 
-    def current_grade(self):
+    def current_grade(self) -> 'Grade':
         return self.roles.order_by(Role.date_started.desc()).first().grade
 
     def promoted(self, promoted_after_date: datetime.date):
@@ -159,6 +159,10 @@ class Role(db.Model):
 
     def __repr__(self):
         return f'<Role held by {self.candidate} at {self.organisation_id}>'
+
+    def is_promotion(self):
+        role_before_this = self.candidate.roles.order_by(Role.date_started.desc()).first()
+        return self.grade.rank > role_before_this.grade.rank
 
 
 class Scheme(db.Model):

--- a/conftest.py
+++ b/conftest.py
@@ -147,7 +147,8 @@ def test_multiple_candidates_multiple_ethnicities(test_session, test_ethnicities
 def candidates_promoter():
     def _promoter(candidates_to_promote, decimal_ratio):
         for candidate in candidates_to_promote[0:int(len(candidates_to_promote) * decimal_ratio)]:
-            candidate.roles.extend([Role(date_started=date(2019, 1, 1)), Role(date_started=date(2020, 3, 1))])
+            candidate.roles.extend([Role(date_started=date(2019, 1, 1)), Role(date_started=date(2020, 3, 1),
+                                                                              temporary_promotion=False)])
         return candidates_to_promote
 
     return _promoter

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -76,10 +76,10 @@ class TestCandidate:
         test_candidate.roles.extend([
             Role(date_started=list_of_role_data[0].get('date-started'),
                  grade=Grade.query.filter_by(value=list_of_role_data[0].get('grade-value')).first(),
-                 temporary_promotion=list_of_role_data[0].get('temporary')),
+                 temporary_promotion=False),
             Role(date_started=list_of_role_data[1].get('date-started'),
                  grade=Grade.query.filter_by(value=list_of_role_data[1].get('grade-value')).first(),
-                 temporary_promotion=list_of_role_data[0].get('temporary'))
+                 temporary_promotion=list_of_role_data[1].get('temporary'))
         ])
         assert test_candidate.promoted('2019-09-01') is expected_outcome
 
@@ -106,13 +106,15 @@ class TestGrade:
 
 class TestRole:
 
-    @pytest.mark.parametrize("role_values, expected_outcome", [
-        (["Grade 7", "Grade 6"], True),
-        (["Grade 7", "Grade 7"], False)
+    @pytest.mark.parametrize("roles_values, expected_outcome", [
+        (["Grade 7", "Grade 6", False], True),  # substantive promotion
+        (["Grade 7", "Grade 7", True], False),  # level transfer
     ])
-    def test_is_promoted_returns_correct_values(self, role_values, expected_outcome, test_session, test_candidate):
+    def test_is_promoted_returns_correct_values(self, roles_values, expected_outcome, test_session, test_candidate):
         test_candidate.roles.extend([
-                    Role(date_started=date(2019, 1, 1), grade=Grade.query.filter_by(value=role_values[0]).first()),
-                    Role(date_started=date(2020, 6, 1), grade=Grade.query.filter_by(value=role_values[1]).first())
+                    Role(date_started=date(2019, 1, 1), grade=Grade.query.filter_by(value=roles_values[0]).first(),
+                         temporary_promotion=False),
+                    Role(date_started=date(2020, 6, 1), grade=Grade.query.filter_by(value=roles_values[1]).first(),
+                         temporary_promotion=roles_values[2])
                 ])
         assert test_candidate.roles[0].is_promotion() is expected_outcome

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 from app.models import FLSLeadership, Leadership, Candidate, Role, Grade
 from datetime import date
+import pytest
 
 
 def test_fls_questions_create_leadership_record(test_session):
@@ -26,14 +27,61 @@ class TestCandidate:
         test_session.commit()
         assert Candidate.query.get(test_candidate.id).current_grade().value == 'Deputy Director (SCS1)'
 
-    def test_promoted_when_started(self, test_candidate, test_session):
-        grades = Grade.query.order_by(Grade.rank.asc()).all()
-        test_candidate.roles = [
-            Role(date_started=date(2019, 1, 1), candidate_id=test_candidate.id, grade=grades[0]),
-            Role(date_started=date(2020, 6, 1), candidate_id=test_candidate.id, grade=grades[-1])
+    @pytest.mark.parametrize(
+        "list_of_role_data, expected_outcome",
+        [
+            (  # substantive promotion after the date
+                    [
+                        {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
+                        {'date-started': date(2020, 6, 1), 'grade-value': "Grade 6", 'temporary': False}
+                    ],
+                    True
+
+            ),
+            (  # temporary promotion after the date
+                    [
+                        {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
+                        {'date-started': date(2020, 6, 1), 'grade-value': "Grade 6", 'temporary': True}
+                    ],
+                    False
+
+            ),
+            (  # level transfer after the date
+                    [
+                        {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
+                        {'date-started': date(2020, 6, 1), 'grade-value': "Grade 7"}
+                    ],
+                    False
+
+            ),
+            (  # definitely a promotion, but one that we can't take credit for
+                    [
+                        {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
+                        {'date-started': date(2019, 10, 1), 'grade-value': "Grade 7", 'temporary': False}
+                    ],
+                    False
+
+            ),
+            (  # level transfer that we can't take credit for
+                    [
+                        {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
+                        {'date-started': date(2019, 10, 1), 'grade-value': "Grade 7"}
+                    ],
+                    False
+
+            ),
         ]
-        test_session.add(test_candidate)
-        assert test_candidate.promoted('2019-09-01')
+    )
+    def test_promoted_when_started(self, list_of_role_data, expected_outcome, test_candidate, test_session):
+        test_candidate.roles.extend([
+            Role(date_started=list_of_role_data[0].get('date-started'),
+                 grade=Grade.query.filter_by(value=list_of_role_data[0].get('grade-value')).first(),
+                 temporary_promotion=list_of_role_data[0].get('temporary')),
+            Role(date_started=list_of_role_data[1].get('date-started'),
+                 grade=Grade.query.filter_by(value=list_of_role_data[1].get('grade-value')).first(),
+                 temporary_promotion=list_of_role_data[0].get('temporary'))
+        ])
+        assert test_candidate.promoted('2019-09-01') is expected_outcome
 
     def test_current_scheme_returns_current_scheme(self, test_candidate_applied_to_fls):
         assert test_candidate_applied_to_fls.current_scheme().name == 'FLS'
@@ -54,3 +102,17 @@ class TestGrade:
         current_grade = Grade(value='One below SCS', rank=5)
         promotion_roles = [grade.value for grade in Grade.new_grades(current_grade)]
         assert promotion_roles == ['Deputy Director (SCS1)', 'Grade 6', 'Grade 7']
+
+
+class TestRole:
+
+    @pytest.mark.parametrize("role_values, expected_outcome", [
+        (["Grade 7", "Grade 6"], True),
+        (["Grade 7", "Grade 7"], False)
+    ])
+    def test_is_promoted_returns_correct_values(self, role_values, expected_outcome, test_session, test_candidate):
+        test_candidate.roles.extend([
+                    Role(date_started=date(2019, 1, 1), grade=Grade.query.filter_by(value=role_values[0]).first()),
+                    Role(date_started=date(2020, 6, 1), grade=Grade.query.filter_by(value=role_values[1]).first())
+                ])
+        assert test_candidate.roles[0].is_promotion() is expected_outcome

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -57,7 +57,7 @@ class TestCandidate:
             (  # definitely a promotion, but one that we can't take credit for
                     [
                         {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                        {'date-started': date(2019, 10, 1), 'grade-value': "Grade 7", 'temporary': False}
+                        {'date-started': date(2019, 8, 1), 'grade-value': "Grade 6", 'temporary': False}
                     ],
                     False
 
@@ -65,7 +65,7 @@ class TestCandidate:
             (  # level transfer that we can't take credit for
                     [
                         {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                        {'date-started': date(2019, 10, 1), 'grade-value': "Grade 7"}
+                        {'date-started': date(2019, 8, 1), 'grade-value': "Grade 7"}
                     ],
                     False
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,43 +31,43 @@ class TestCandidate:
         "list_of_role_data, expected_outcome",
         [
             (  # substantive promotion after the date
-                    [
-                        {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                        {'date-started': date(2020, 6, 1), 'grade-value': "Grade 6", 'temporary': False}
-                    ],
-                    True
+                [
+                    {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
+                    {'date-started': date(2020, 6, 1), 'grade-value': "Grade 6", 'temporary': False}
+                ],
+                True
 
             ),
             (  # temporary promotion after the date
-                    [
-                        {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                        {'date-started': date(2020, 6, 1), 'grade-value': "Grade 6", 'temporary': True}
-                    ],
-                    False
+                [
+                    {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
+                    {'date-started': date(2020, 6, 1), 'grade-value': "Grade 6", 'temporary': True}
+                ],
+                False
 
             ),
             (  # level transfer after the date
-                    [
-                        {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                        {'date-started': date(2020, 6, 1), 'grade-value': "Grade 7"}
-                    ],
-                    False
+                [
+                    {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
+                    {'date-started': date(2020, 6, 1), 'grade-value': "Grade 7"}
+                ],
+                False
 
             ),
             (  # definitely a promotion, but one that we can't take credit for
-                    [
-                        {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                        {'date-started': date(2019, 8, 1), 'grade-value': "Grade 6", 'temporary': False}
-                    ],
-                    False
+                [
+                    {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
+                    {'date-started': date(2019, 8, 1), 'grade-value': "Grade 6", 'temporary': False}
+                ],
+                False
 
             ),
             (  # level transfer that we can't take credit for
-                    [
-                        {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                        {'date-started': date(2019, 8, 1), 'grade-value': "Grade 7"}
-                    ],
-                    False
+                [
+                    {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
+                    {'date-started': date(2019, 8, 1), 'grade-value': "Grade 7"}
+                ],
+                False
 
             ),
         ]
@@ -112,9 +112,9 @@ class TestRole:
     ])
     def test_is_promoted_returns_correct_values(self, roles_values, expected_outcome, test_session, test_candidate):
         test_candidate.roles.extend([
-                    Role(date_started=date(2019, 1, 1), grade=Grade.query.filter_by(value=roles_values[0]).first(),
-                         temporary_promotion=False),
-                    Role(date_started=date(2020, 6, 1), grade=Grade.query.filter_by(value=roles_values[1]).first(),
-                         temporary_promotion=roles_values[2])
-                ])
+            Role(date_started=date(2019, 1, 1), grade=Grade.query.filter_by(value=roles_values[0]).first(),
+                 temporary_promotion=False),
+            Role(date_started=date(2020, 6, 1), grade=Grade.query.filter_by(value=roles_values[1]).first(),
+                 temporary_promotion=roles_values[2])
+        ])
         assert test_candidate.roles[0].is_promotion() is expected_outcome


### PR DESCRIPTION
This was surprisingly hard, but I'm happy with the result. Promotions now only count if, since the input date, a candidate has had a role that is both a higher rank **and** substantive. I may need to extend this method for temporary promotions as well