### PR TITLE
Promotion report now contains temporary promotion numbers

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -64,18 +64,20 @@ class Candidate(db.Model):
     def current_grade(self) -> 'Grade':
         return self.roles.order_by(Role.date_started.desc()).first().grade
 
-    def promoted(self, promoted_after_date: datetime.date):
+    def promoted(self, promoted_after_date: datetime.date, temporary=False):
         """
         Returns whether this candidate was promoted after the passed date. Promotions are only considered if they're
-        substantive
+        substantive. There is a flag is users want to see temporary promotions instead
         :param promoted_after_date:
         :type promoted_after_date:
+        :param temporary: Whether the user wants temporary or substantive promotions
+        :type temporary: bool
         :return:
         :rtype:
         """
         roles_after_date = self.roles.filter(and_(
             Role.date_started >= promoted_after_date,
-            Role.temporary_promotion.is_(False),
+            Role.temporary_promotion.is_(temporary),
         )).order_by(Role.date_started.desc()).all()
         return len(roles_after_date) > 0
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -9,9 +9,13 @@ class TestReports:
         "report_type, parameters, white_british_promoted, black_british_promoted, scheme_id, expected_output",
         [
             (PromotionReport, ['ethnicity', 'FLS', 2019], .5, .7, 1,
-             ['characteristic,number promoted,percentage promoted\r', 'White British,5,50%\r', 'Black British,7,70%\r', '']),
+             ['characteristic,number substantively promoted,percentage substantively promoted,'
+              'number temporarily promoted,percentage temporarily promoted,total in group\r',
+              'White British,5,50%,0,0%,10\r', 'Black British,7,70%,0,0%,10\r', '']),
             (PromotionReport, ['ethnicity', 'SLS', 2019], .4, .6, 2,
-             ['characteristic,number promoted,percentage promoted\r', 'White British,4,40%\r', 'Black British,6,60%\r', '']),
+             ['characteristic,number substantively promoted,percentage substantively promoted,'
+              'number temporarily promoted,percentage temporarily promoted,total in group\r',
+              'White British,4,40%,0,0%,10\r', 'Black British,6,60%,0,0%,10\r', '']),
         ]
     )
     def test_reports(self, report_type: Report, parameters: List[str], white_british_promoted, black_british_promoted,


### PR DESCRIPTION
This was quite a difficult shift, but the Promotion report at least now contains columns detailing the number of people on temporary promotion