### PR TITLE
Get the methods right and the rest will follow

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -209,6 +209,10 @@ class Application(db.Model):
     cohort = db.Column(db.Integer, unique=False)
     withdrawn = db.Column(db.Boolean(), default=False)
 
+    def defer(self, date_to_defer_to: datetime.date):
+        self.scheme_start_date = date_to_defer_to
+        return None
+
 
 class Leadership(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/app/models.py
+++ b/app/models.py
@@ -16,7 +16,7 @@ login_manager = LoginManager()
 class CandidateGetterMixin:
     @declared_attr
     def candidates(cls):
-        return db.relationship("Candidate")
+        return db.relationship("Candidate", backref=cls.__name__.lower())
 
 
 class User(UserMixin, db.Model):

--- a/conftest.py
+++ b/conftest.py
@@ -187,7 +187,8 @@ def candidates_promoter():
 def scheme_appender(test_session):
     def _add_scheme(candidates_to_add, scheme_id_to_add):
         for candidate in candidates_to_add:
-            candidate.applications.append(Application(application_date=date(2019, 6, 1), scheme_id=scheme_id_to_add))
+            candidate.applications.append(Application(
+                application_date=date(2018, 8, 1), scheme_id=scheme_id_to_add, scheme_start_date=date(2019, 3, 1)))
     return _add_scheme
 
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,7 +1,8 @@
 import pytest
 from typing import List
-from reporting.reports import CharacteristicPromotionReport, BooleanCharacteristicPromotionReport
-from app.models import Ethnicity, Candidate
+from reporting.reports import CharacteristicPromotionReport, BooleanCharacteristicPromotionReport, PromotionReport
+from app.models import Ethnicity, Candidate, Application
+from datetime import date
 
 
 class TestReports:
@@ -32,6 +33,52 @@ class TestReports:
         output = CharacteristicPromotionReport(*parameters).return_data()
         assert output.data.decode("UTF-8").split('\n') == expected_output
 
+    def test_deferred_candidates_are_not_counted(self, test_session, candidates_promoter):
+        """
+        Two candidates apply to the 2019 intake and are successful. One defers to 2019. Both are promoted in the
+        following year. How many "successes" should be counted for the programme? The answer should be one, because only
+        one is actually on the programme at the time
+        """
+        test_session.add(Ethnicity(id=1, value="Prefer not to say"))
+        test_session.commit()
+
+        candidates = [Candidate(ethnicity_id=1) for i in range(2)]
+        # all candidates apply for the 2019 intake and are successful
+        for candidate in candidates:
+            candidate.applications.append(
+                Application(scheme_id=1, application_date=date(2018, 6, 1), scheme_start_date=date(2019, 3, 1),
+                            successful=True)
+            )
+        # all candidates are substantively promoted
+        candidates_promoter(candidates, 1, temporary=False)
+        # one candidate defers to the 2020 intake
+        candidates[0].applications[0].defer(date_to_defer_to=date(2020, 3, 1))
+        # save to the database
+        test_session.add_all(candidates)
+        test_session.commit()
+
+        data = CharacteristicPromotionReport('FLS', '2019', 'ethnicity').get_data()
+        expected_output = [['Prefer not to say', 1, 1.0, 0, 0.0, 1]]
+        assert data == expected_output
+
+
+class TestPromotionReport:
+    def test_eligible_candidates(self, test_session, candidates_promoter):
+        test_session.add(Ethnicity(id=1, value="Prefer not to say"))
+        test_session.commit()
+
+        candidates = [Candidate(ethnicity_id=1) for i in range(2)]
+        for candidate in candidates:
+            candidate.applications.append(
+                Application(scheme_id=1, application_date=date(2018, 6, 1), scheme_start_date=date(2019, 3, 1))
+            )
+        test_session.add_all(candidates)
+        candidates[0].applications[0].defer(date_to_defer_to=date(2020, 3, 1))
+        test_session.commit()
+
+        data = PromotionReport('FLS', '2019').eligible_candidates()
+        assert len(data) == 1
+
 
 class TestBooleanCharacteristicPromotionReport:
     def test_get_data(self, disability_with_without_no_answer, candidates_promoter, scheme_appender, test_session):
@@ -50,8 +97,7 @@ class TestBooleanCharacteristicPromotionReport:
             scheme_appender(group, scheme_id_to_add=1)
 
         test_session.commit()
-
-        output = BooleanCharacteristicPromotionReport('FLS', '2018', 'long_term_health_condition').get_data()
+        output = BooleanCharacteristicPromotionReport('FLS', '2019', 'long_term_health_condition').get_data()
         expected_output = [
             ["People with a disability", 3, 0.3, 0, 0.0, 10],
             ["People without a disability", 4, 0.4, 0, 0.0, 10],


### PR DESCRIPTION
No changes to the interface in this PR. In fact, there should be no changes to users yet. What I have done is implemented the backend work to make sure that when reporting, candidates who've deferred their programme (but still been promoted) aren't counted in the promotion statistics.

Next: allow users to defer candidates