### PR TITLE
Add deferral option

### DIFF
--- a/app/templates/choose-update.html
+++ b/app/templates/choose-update.html
@@ -31,19 +31,23 @@
                 </h2>
             </legend>
 
-            <div class="govuk-radios govuk-radios--inline">
-                <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="update-type-1" name="update-type" type="radio" value="role">
-                    <label class="govuk-label govuk-radios__label" for="update-type-1">
-                        Role
-                    </label>
-                </div>
-                <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="update-type-2" name="update-type" type="radio" value="name">
-                    <label class="govuk-label govuk-radios__label" for="update-type-2">
-                        Name
-                    </label>
-                </div>
+            <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="update-type-1" name="update-type" type="radio" value="role">
+                <label class="govuk-label govuk-radios__label" for="update-type-1">
+                    Role
+                </label>
+            </div>
+            <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="update-type-2" name="update-type" type="radio" value="name">
+                <label class="govuk-label govuk-radios__label" for="update-type-2">
+                    Name
+                </label>
+            </div>
+            <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="update-type-3" name="update-type" type="radio" value="deferral">
+                <label class="govuk-label govuk-radios__label" for="update-type-3">
+                    Deferral
+                </label>
             </div>
         </div>
         <div class="input submit">

--- a/app/templates/updates/deferral.html
+++ b/app/templates/updates/deferral.html
@@ -1,0 +1,16 @@
+{% extends 'updates/update-layout.html' %}
+
+{% block form_content %}
+    <div class="govuk-form-group">
+        <div class="govuk-form-group">
+            <label class="govuk-label" for="new-intake-year">
+                New intake year
+            </label>
+            <span id="first-name-hint" class="govuk-hint">
+                Intake year should be the year the scheme will start - for example, if applicants apply to the Future
+                Leaders Scheme in August 2018 but will start in March 2019, the intake year is 2019
+            </span>
+            <input class="govuk-input govuk-input--width-4" id="new-intake-year-name" name="new-intake-year" type="number">
+        </div>
+    </div>
+{% endblock %}

--- a/modules/seed.py
+++ b/modules/seed.py
@@ -93,6 +93,7 @@ def generate_known_candidate():
 
 def generate_random_candidate():
     return Candidate(email_address=f"{random_string(16)}@gov.uk",
+                     first_name="Test", last_name="Candidate",
                      joining_date=date(random.randrange(1960, 2018), random.randrange(1, 12), random.randrange(1, 28)),
                      completed_fast_stream=random.choice([True, False]),
                      joining_grade=(Grade.query.filter_by(rank=6).first()).id,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -28,6 +28,13 @@ class TestNewEmail:
         assert "new-test-email@gov.uk" == session.get("new-email")
 
 
+class TestUpdateType:
+    @pytest.mark.parametrize("option", ["Role", "Name", "Deferral"])
+    def test_get(self, option, test_client, logged_in_user):
+        result = test_client.get(url_for('route_blueprint.choose_update'))
+        assert option in result.data.decode("UTF-8")
+
+
 class TestSingleUpdate:
     def test_get(self, test_client, test_candidate, logged_in_user, test_roles):
         with test_client.session_transaction() as sess:
@@ -60,7 +67,9 @@ class TestSearchCandidate:
         result = test_client.get('/update/search-candidate')
         assert "Most recent candidate email address" in result.data.decode("UTF-8")
 
-    @pytest.mark.parametrize("update_type, expected_title", [("role", "Role update"), ("name", "Update name")])
+    @pytest.mark.parametrize("update_type, expected_title",
+                             [("role", "Role update"), ("name", "Update name"), ("deferral", "Defer intake year")]
+                             )
     def test_post(self, update_type, expected_title, test_client, test_candidate, logged_in_user, test_roles):
         with test_client.session_transaction() as sess:
             sess['bulk-single'] = "single"
@@ -68,7 +77,6 @@ class TestSearchCandidate:
         data = {'candidate-email': 'test.candidate@numberten.gov.uk'}
         result = test_client.post('/update/search-candidate', data=data, follow_redirects=True,
                                   headers={'content-type': 'application/x-www-form-urlencoded'})
-        print(result.data.decode("UTF-8"))
 
         assert expected_title in result.data.decode("UTF-8")
 


### PR DESCRIPTION
Users can now defer candidates's scheme_start_date. The user journey is as follows:

<img width="1036" alt="Screen Shot 2019-06-22 at 09 42 12" src="https://user-images.githubusercontent.com/3410350/59961615-0b970380-94d2-11e9-9bc2-f5b6bf29c4e9.png">

(Notice that the radios are now vertically stacked, [in line with the design system advice](https://design-system.service.gov.uk/components/radios/) )

Users search for the candidate by email address
<img width="1022" alt="Screen Shot 2019-06-22 at 09 44 18" src="https://user-images.githubusercontent.com/3410350/59961639-50bb3580-94d2-11e9-8d03-b232091d66e8.png">

They add the new intake year. There's content here to explain what year to input
<img width="1004" alt="Screen Shot 2019-06-22 at 09 46 44" src="https://user-images.githubusercontent.com/3410350/59961662-ad1e5500-94d2-11e9-9b5f-562c2ed7dfba.png">
Finally, a very skinny check answers page:
<img width="1052" alt="Screen Shot 2019-06-22 at 09 47 54" src="https://user-images.githubusercontent.com/3410350/59961671-d808a900-94d2-11e9-8207-e8ee8ab3877a.png">
