### PR TITLE
Add third line to OfferReport

### DIFF
--- a/reporting/reports.py
+++ b/reporting/reports.py
@@ -174,7 +174,9 @@ class OfferPromotionReport(PromotionReport):
     def get_row_metadata(self):
         return [
             (f"Candidates eligible for {self.upper_attribute}", self.eligible_candidates()),
-            (f"Candidates on {self.upper_attribute}", self.candidates_on_offer(self.attribute))
+            (f"Candidates on {self.upper_attribute}", self.candidates_on_offer(self.attribute)),
+            (f"Candidates not on {self.upper_attribute}",
+             list(set(self.eligible_candidates()) - set(self.candidates_on_offer(self.attribute))))
         ]
 
     def candidates_on_offer(self, offer):

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -125,5 +125,6 @@ class TestDeltaOfferPromotionReport:
         expected_output = [
             ["Candidates eligible for DELTA", 6, 0.6, 0, 0.0, 10],
             ["Candidates on DELTA", 4, 0.8, 0, 0.0, 5],
+            ["Candidates not on DELTA", 2, 0.4, 0, 0.0, 5]
         ]
         assert expected_output == output


### PR DESCRIPTION
Offer reports should include the percentage candidates promoted not on the offer, to evidence value for money of the offer