### PR TITLE
Make sure Cabinet Office doesn't bork seed script

### DIFF
--- a/modules/seed.py
+++ b/modules/seed.py
@@ -38,7 +38,7 @@ def generate_random_fixed_data():
     genders = [Gender(id=i, value=value) for i, value
                in enumerate(["Male", "Female", "I identify in another way", "Prefer not to say"])]
 
-    organisations.append(Organisation(name='Cabinet Office'))
+    organisations.append(Organisation(id=len(organisations) + 1, name='Cabinet Office'))
     grades = [
         'Prefer not to say',
         'AA – Administrative Assistant',


### PR DESCRIPTION
When trying to install this on a colleague's machine we found that the seed script would break when trying to add in the Cabinet Office. This fix will ensure the Cabinet Office is given an id that is not already assigned to another organisation