### PR TITLE
Alter Candidate.promoted method

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -85,7 +85,7 @@ class Candidate(db.Model):
     def current_grade(self) -> 'Grade':
         return self.roles.order_by(Role.date_started.desc()).first().grade
 
-    def promoted(self, promoted_after_date: datetime.date, temporary=False):
+    def promoted(self, promoted_after_date: datetime.date, promoted_before_date=None, temporary=False):
         """
         Returns whether this candidate was promoted after the passed date. Promotions are only considered if they're
         substantive. There is a flag is users want to see temporary promotions instead
@@ -96,10 +96,13 @@ class Candidate(db.Model):
         :return:
         :rtype:
         """
+        if not promoted_before_date:
+            promoted_before_date = datetime.today()
         roles_after_date = self.roles.filter(and_(
             Role.date_started >= promoted_after_date,
+            Role.date_started <= promoted_before_date,
             Role.temporary_promotion.is_(temporary),
-        )).order_by(Role.date_started.desc()).all()
+        )).all()
         return len(roles_after_date) > 0
 
     def current_scheme(self) -> 'Scheme':

--- a/conftest.py
+++ b/conftest.py
@@ -178,7 +178,7 @@ def disability_with_without_no_answer(test_session):
 def candidates_promoter():
     def _promoter(candidates_to_promote, decimal_ratio, temporary=False):
         for candidate in candidates_to_promote[0:int(len(candidates_to_promote) * decimal_ratio)]:
-            candidate.roles.extend([Role(date_started=date(2019, 1, 1)), Role(date_started=date(2020, 3, 1),
+            candidate.roles.extend([Role(date_started=date(2018, 1, 1)), Role(date_started=date(2019, 3, 1),
                                                                               temporary_promotion=temporary)])
         return candidates_to_promote
 

--- a/reporting/base_promotion_report.py
+++ b/reporting/base_promotion_report.py
@@ -19,7 +19,8 @@ class PromotionReport(Report, ABC):
         self.attribute = attribute
         self.intake_date = date(int(year), 3, 1)  # assuming it starts in March every year
         self.scheme = Scheme.query.filter_by(name=f'{scheme}').first()
-        self.promoted_before_date = date(int(year) + 1, 3, 1)  # can't take credit for promotions within first 3 months
+        # we only take credit for promotions that happen after candidates find out they're successful
+        self.promotions_count_from = date(int(year) - 1, 12, 1)
         self.headers = ['characteristic', 'number substantively promoted', 'percentage substantively promoted',
                         'number temporarily promoted', 'percentage temporarily promoted', 'total in group']
         self.filename = f"promotions-by-{attribute}-{scheme}-{year}-generated-{date.today().strftime('5%d-%m-%Y')}"
@@ -59,7 +60,8 @@ class PromotionReport(Report, ABC):
         return [application.candidate for application in eligible_applications]
 
     def promoted_candidates(self, temporary, candidates: List[Candidate]):
-        return [candidate for candidate in candidates if candidate.promoted(self.promoted_before_date, temporary)]
+        return [candidate for candidate in candidates if candidate.promoted(self.promotions_count_from,
+                                                                            temporary=temporary)]
 
     def write_row(self, row_data, data_object, csv_writer):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,7 +33,7 @@ class TestCandidate:
             (  # substantive promotion after the date
                 [
                     {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                    {'date-started': date(2020, 6, 1), 'grade-value': "Grade 6", 'temporary': False}
+                    {'date-started': date(2019, 12, 1), 'grade-value': "Grade 6", 'temporary': False}
                 ],
                 True
 
@@ -41,7 +41,7 @@ class TestCandidate:
             (  # temporary promotion after the date
                 [
                     {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                    {'date-started': date(2020, 6, 1), 'grade-value': "Grade 6", 'temporary': True}
+                    {'date-started': date(2019, 12, 1), 'grade-value': "Grade 6", 'temporary': True}
                 ],
                 False
 
@@ -49,23 +49,23 @@ class TestCandidate:
             (  # level transfer after the date
                 [
                     {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                    {'date-started': date(2020, 6, 1), 'grade-value': "Grade 7"}
+                    {'date-started': date(2019, 12, 1), 'grade-value': "Grade 7"}
                 ],
                 False
 
             ),
-            (  # definitely a promotion, but one that we can't take credit for
+            (  # a promotion that hasn't happened yet
                 [
                     {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                    {'date-started': date(2019, 8, 1), 'grade-value': "Grade 6", 'temporary': False}
+                    {'date-started': date(2020, 3, 1), 'grade-value': "Grade 6", 'temporary': False}
                 ],
                 False
 
             ),
-            (  # level transfer that we can't take credit for
+            (  # level transfer that hasn't happened yet
                 [
                     {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                    {'date-started': date(2019, 8, 1), 'grade-value': "Grade 7"}
+                    {'date-started': date(2020, 3, 1), 'grade-value': "Grade 7"}
                 ],
                 False
 
@@ -73,6 +73,7 @@ class TestCandidate:
         ]
     )
     def test_promoted_when_started(self, list_of_role_data, expected_outcome, test_candidate, test_session):
+        test_candidate: Candidate
         test_candidate.roles.extend([
             Role(date_started=list_of_role_data[0].get('date-started'),
                  grade=Grade.query.filter_by(value=list_of_role_data[0].get('grade-value')).first(),
@@ -81,7 +82,7 @@ class TestCandidate:
                  grade=Grade.query.filter_by(value=list_of_role_data[1].get('grade-value')).first(),
                  temporary_promotion=list_of_role_data[1].get('temporary'))
         ])
-        assert test_candidate.promoted('2019-09-01') is expected_outcome
+        assert test_candidate.promoted('2019-09-01', date(2020, 1, 1)) is expected_outcome
 
     def test_current_scheme_returns_current_scheme(self, test_candidate_applied_to_fls):
         assert test_candidate_applied_to_fls.current_scheme().name == 'FLS'

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -5,6 +5,7 @@ from reporting.promotion_reports import CharacteristicPromotionReport, BooleanCh
 from reporting.base_promotion_report import PromotionReport
 from app.models import Ethnicity, Candidate, Application
 from datetime import date
+from freezegun import freeze_time
 
 
 class TestReports:
@@ -21,6 +22,7 @@ class TestReports:
               'White British,4,40%,0,0%,10\r', 'Black British,6,60%,0,0%,10\r', '']),
         ]
     )
+    @freeze_time(date(2020, 1, 1))  # we're running this report on 1 Jan 2020
     def test_reports(self, parameters: List[str], white_british_promoted, black_british_promoted,
                      scheme_id, expected_output: str, test_ethnicities, scheme_appender,
                      test_multiple_candidates_multiple_ethnicities, candidates_promoter):


### PR DESCRIPTION
I've changed the signature of this method to accept a `promoted_before_date` argument. This extension will allow the DetailedReport class to only report on promotions before a certain date