### PR TITLE
Update model to use promotions table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -96,12 +96,17 @@ class Candidate(db.Model):
         :return:
         :rtype:
         """
+        if temporary:
+            role_change = Promotion.query.filter_by(value="temporary").first()
+        else:
+            role_change = Promotion.query.filter_by(value="substantive").first()
         if not promoted_before_date:
             promoted_before_date = datetime.today()
         roles_after_date = self.roles.filter(and_(
             Role.date_started >= promoted_after_date,
             Role.date_started <= promoted_before_date,
             Role.temporary_promotion.is_(temporary),
+            Role.role_change == role_change,
         )).all()
         return len(roles_after_date) > 0
 

--- a/app/models.py
+++ b/app/models.py
@@ -105,7 +105,6 @@ class Candidate(db.Model):
         roles_after_date = self.roles.filter(and_(
             Role.date_started >= promoted_after_date,
             Role.date_started <= promoted_before_date,
-            Role.temporary_promotion.is_(temporary),
             Role.role_change == role_change,
         )).all()
         return len(roles_after_date) > 0

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -124,8 +124,7 @@ def check_your_answers():
             role_data = session.pop('new-role', None)
             candidate.roles.append(Role(
                 date_started=date(role_data['start-date-year'], role_data['start-date-month'],
-                                  role_data['start-date-day']),
-                temporary_promotion=bool(role_data['temporary-promotion']), organisation_id=role_data['new-org'],
+                                  role_data['start-date-day']), organisation_id=role_data['new-org'],
                 profession_id=role_data['new-profession'], location_id=role_data['new-location'],
                 grade_id=role_data['new-grade'], role_name=role_data['new-title']
             ))

--- a/app/templates/partials/accordion-section-role.html
+++ b/app/templates/partials/accordion-section-role.html
@@ -9,12 +9,12 @@
     <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
         <ul class="govuk-list govuk-list--bullet">
             <li>This was a {{ role.grade.value }} role</li>
-            {% if role.temporary_promotion %}
+            {% if role.role_change.value == 'temporary' %}
                 <li>This was a temporary promotion</li>
-            {% elif role.temporary_promotion == false %}
+            {% elif role.role_change.value == 'substantive' %}
                 <li>This was a substantive promotion</li>
             {% else %}
-                <li>This was a level transfer</li>
+                <li>This was a {{ role.role_change.value }}</li>
             {% endif %}
             <li>This role is based in {{ role.location.value }}</li>
             <li>The candidate held this role from {{ role.date_started }}</li>

--- a/conftest.py
+++ b/conftest.py
@@ -77,7 +77,7 @@ def test_candidate(test_session):
     candidate.joining_date = date(2010, 5, 1)
     candidate.joining_grade = 1
     candidate.roles.append(
-        Role(date_started=date(2010, 5, 1), temporary_promotion=False, grade_id=2, location_id=1))
+        Role(date_started=date(2010, 5, 1), grade_id=2, location_id=1, role_change_id=2))
     test_data = {
         'grades': [Grade(value='Band A', rank=2), Grade(value='SCS3', rank=1)],
         'test_candidates': [candidate],
@@ -98,7 +98,7 @@ def test_candidate_applied_to_fls(test_candidate, test_session):
 
 @pytest.fixture
 def test_candidate_applied_and_promoted(test_candidate_applied_to_fls, test_session):
-    test_candidate_applied_to_fls.roles.append(Role(date_started=date(2020, 1, 1), temporary_promotion=False))
+    test_candidate_applied_to_fls.roles.append(Role(date_started=date(2020, 1, 1), role_change_id=2))
     test_session.add(test_candidate_applied_to_fls)
     test_session.commit()
     yield
@@ -185,7 +185,6 @@ def candidates_promoter():
             change_type = Promotion.query.filter(Promotion.value == "substantive").first()
         for candidate in candidates_to_promote[0:int(len(candidates_to_promote) * decimal_ratio)]:
             candidate.roles.extend([Role(date_started=date(2018, 1, 1)), Role(date_started=date(2019, 3, 1),
-                                                                              temporary_promotion=temporary,
                                                                               role_change=change_type)])
         return candidates_to_promote
 

--- a/conftest.py
+++ b/conftest.py
@@ -179,9 +179,14 @@ def disability_with_without_no_answer(test_session):
 @pytest.fixture
 def candidates_promoter():
     def _promoter(candidates_to_promote, decimal_ratio, temporary=False):
+        if temporary:
+            change_type = Promotion.query.filter(Promotion.value == "temporary").first()
+        else:
+            change_type = Promotion.query.filter(Promotion.value == "substantive").first()
         for candidate in candidates_to_promote[0:int(len(candidates_to_promote) * decimal_ratio)]:
             candidate.roles.extend([Role(date_started=date(2018, 1, 1)), Role(date_started=date(2019, 3, 1),
-                                                                              temporary_promotion=temporary)])
+                                                                              temporary_promotion=temporary,
+                                                                              role_change=change_type)])
         return candidates_to_promote
 
     return _promoter

--- a/conftest.py
+++ b/conftest.py
@@ -49,6 +49,8 @@ def test_session(db):
     db.session.add(test_user)
 
     db.session.add_all([Scheme(id=1, name='FLS'), Scheme(id=2, name='SLS')])
+    db.session.add_all([Promotion(id=1, value="temporary"), Promotion(id=2, value="substantive"),
+                        Promotion(id=3, value="level transfer"), Promotion(id=4, value="demotion")])
     db.session.add_all([
         Grade(id=2, value='Grade 7', rank=6), Grade(id=3, value='Grade 6', rank=5),
         Grade(id=4, value='Deputy Director (SCS1)', rank=4), Grade(id=1, value='Admin Assistant (AA)', rank=7)

--- a/modules/seed.py
+++ b/modules/seed.py
@@ -123,7 +123,7 @@ def generate_known_candidate():
         first_name="Test", last_name="Candidate", completed_fast_stream=True,
         joining_grade=Grade.query.filter(Grade.value.like("%Faststream%")).first().id,
         age_range_id=2, ethnicity_id=1, working_pattern_id=1, belief_id=1, gender_id=1, sexuality_id=1,
-        roles=[Role(date_started=date(2015, 9, 2), temporary_promotion=False, profession_id=1,
+        roles=[Role(date_started=date(2015, 9, 2), profession_id=1, role_change_id=2,
                     organisation_id=Organisation.query.filter(Organisation.name == 'Cabinet Office').first().id,
                     grade=Grade.query.filter(Grade.value.like("%Faststream%")).first(),
                     location=Location.query.filter_by(value="London").first())
@@ -145,10 +145,10 @@ def generate_random_candidate():
                      caring_responsibility=random.choice([True, False, False]),
                      belief=random.choice(Belief.query.all()), sexuality=random.choice(Sexuality.query.all()),
                      working_pattern=random.choice(WorkingPattern.query.all()),
-                     roles=[Role(date_started=date(2015, 9, 2), temporary_promotion=False,
+                     roles=[Role(date_started=date(2015, 9, 2),
                                  organisation_id=random.choice(Organisation.query.all()).id,
                                  grade=Grade.query.filter(Grade.value.like("%Faststream%")).first(),
-                                 location=random.choice(Location.query.all()))
+                                 location=random.choice(Location.query.all()), role_change_id=2),
                             ]
                      )
 
@@ -166,9 +166,9 @@ def promote_candidate(candidate: Candidate, role_change_type=None):
     if role_change_type is None:
         role_change_type = random.choice(["substantive", "temporary", "level transfer"])
     candidate.roles.extend([
-        Role(date_started=date(2018, 1, 1), temporary_promotion=False,
+        Role(date_started=date(2018, 1, 1),
              role_change=Promotion.query.filter(Promotion.value == "substantive").first()),
-        Role(date_started=date(2019, 6, 1), temporary_promotion=None,
+        Role(date_started=date(2019, 6, 1),
              role_change=Promotion.query.filter(Promotion.value == f"{role_change_type}").first())
     ])
     return candidate

--- a/modules/seed.py
+++ b/modules/seed.py
@@ -108,10 +108,13 @@ def generate_random_fixed_data():
         ['Full time', 'Job share', 'Part time', 'Prefer not to say', 'Flexible working', 'Term time']
     )]
 
+    promotions = [Promotion(id=1, value="temporary"), Promotion(id=2, value="substantive"),
+                  Promotion(id=3, value="level transfer"), Promotion(id=4, value="demotion")]
+
     return {'organisations': organisations, 'grades': grades, 'professions': professions, 'locations': locations,
             'ethnicities': ethnic_groups, 'schemes': [Scheme(id=1, name='FLS'), Scheme(id=2, name='SLS')],
             'ages': ages, 'genders': genders, 'sexuality': sexual_orientation, 'beliefs': beliefs,
-            'working_patterns': working_patterns}
+            'working_patterns': working_patterns, 'promotions': promotions}
 
 
 def generate_known_candidate():
@@ -159,11 +162,15 @@ def apply_candidate_to_scheme(scheme_name: str, candidate: Candidate, meta=False
     return candidate
 
 
-def promote_candidate(candidate: Candidate, temporary=None):
-    if temporary is None:
-        temporary = random.choice([True, False])
-    candidate.roles.extend([Role(date_started=date(2018, 1, 1), temporary_promotion=False),
-                            Role(date_started=date(2019, 6, 1), temporary_promotion=temporary)])
+def promote_candidate(candidate: Candidate, role_change_type=None):
+    if role_change_type is None:
+        role_change_type = random.choice(["substantive", "temporary", "level transfer"])
+    candidate.roles.extend([
+        Role(date_started=date(2018, 1, 1), temporary_promotion=False,
+             role_change=Promotion.query.filter(Promotion.value == "substantive").first()),
+        Role(date_started=date(2019, 6, 1), temporary_promotion=None,
+             role_change=Promotion.query.filter(Promotion.value == f"{role_change_type}").first())
+    ])
     return candidate
 
 
@@ -200,7 +207,7 @@ def commit_data():
 
 def clear_old_data():
     tables = [Application, Role, Candidate, Organisation, Profession, Grade, Location, Ethnicity, Scheme, AgeRange,
-              Gender, Sexuality, AgeRange, Belief, WorkingPattern, User]
+              Gender, Sexuality, AgeRange, Belief, WorkingPattern, Promotion, User]
     for table in tables:
         table.query.delete()
         db.session.commit()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,4 @@
-from app.models import FLSLeadership, Leadership, Candidate, Role, Grade, Application
+from app.models import FLSLeadership, Leadership, Candidate, Role, Grade, Application, Promotion
 from datetime import date
 import pytest
 
@@ -73,6 +73,10 @@ class TestCandidate:
         ]
     )
     def test_promoted_when_started(self, list_of_role_data, expected_outcome, test_candidate, test_session):
+        if list_of_role_data[1].get('temporary'):
+            role_change = Promotion.query.filter_by(value="temporary").first()
+        else:
+            role_change = Promotion.query.filter_by(value="substantive").first()
         test_candidate: Candidate
         test_candidate.roles.extend([
             Role(date_started=list_of_role_data[0].get('date-started'),
@@ -80,7 +84,7 @@ class TestCandidate:
                  temporary_promotion=False),
             Role(date_started=list_of_role_data[1].get('date-started'),
                  grade=Grade.query.filter_by(value=list_of_role_data[1].get('grade-value')).first(),
-                 temporary_promotion=list_of_role_data[1].get('temporary'))
+                 temporary_promotion=list_of_role_data[1].get('temporary'), role_change=role_change)
         ])
         assert test_candidate.promoted('2019-09-01', date(2020, 1, 1)) is expected_outcome
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,7 +33,7 @@ class TestCandidate:
             (  # substantive promotion after the date
                 [
                     {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                    {'date-started': date(2019, 12, 1), 'grade-value': "Grade 6", 'temporary': False}
+                    {'date-started': date(2019, 12, 1), 'grade-value': "Grade 6", 'role-change': 'substantive'}
                 ],
                 True
 
@@ -41,7 +41,7 @@ class TestCandidate:
             (  # temporary promotion after the date
                 [
                     {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                    {'date-started': date(2019, 12, 1), 'grade-value': "Grade 6", 'temporary': True}
+                    {'date-started': date(2019, 12, 1), 'grade-value': "Grade 6", 'role-change': 'temporary'}
                 ],
                 False
 
@@ -49,7 +49,7 @@ class TestCandidate:
             (  # level transfer after the date
                 [
                     {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                    {'date-started': date(2019, 12, 1), 'grade-value': "Grade 7"}
+                    {'date-started': date(2019, 12, 1), 'grade-value': "Grade 7", 'role-change': 'level transfer'}
                 ],
                 False
 
@@ -57,7 +57,7 @@ class TestCandidate:
             (  # a promotion that hasn't happened yet
                 [
                     {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                    {'date-started': date(2020, 3, 1), 'grade-value': "Grade 6", 'temporary': False}
+                    {'date-started': date(2020, 3, 1), 'grade-value': "Grade 6", 'role-change': 'substantive'}
                 ],
                 False
 
@@ -65,7 +65,7 @@ class TestCandidate:
             (  # level transfer that hasn't happened yet
                 [
                     {'date-started': date(2019, 1, 1), 'grade-value': "Grade 7"},
-                    {'date-started': date(2020, 3, 1), 'grade-value': "Grade 7"}
+                    {'date-started': date(2020, 3, 1), 'grade-value': "Grade 7", 'role-change': 'level transfer'}
                 ],
                 False
 
@@ -73,18 +73,14 @@ class TestCandidate:
         ]
     )
     def test_promoted_when_started(self, list_of_role_data, expected_outcome, test_candidate, test_session):
-        if list_of_role_data[1].get('temporary'):
-            role_change = Promotion.query.filter_by(value="temporary").first()
-        else:
-            role_change = Promotion.query.filter_by(value="substantive").first()
+        role_change = Promotion.query.filter_by(value=list_of_role_data[1].get('role-change')).first()
         test_candidate: Candidate
         test_candidate.roles.extend([
             Role(date_started=list_of_role_data[0].get('date-started'),
-                 grade=Grade.query.filter_by(value=list_of_role_data[0].get('grade-value')).first(),
-                 temporary_promotion=False),
+                 grade=Grade.query.filter_by(value=list_of_role_data[0].get('grade-value')).first()),
             Role(date_started=list_of_role_data[1].get('date-started'),
                  grade=Grade.query.filter_by(value=list_of_role_data[1].get('grade-value')).first(),
-                 temporary_promotion=list_of_role_data[1].get('temporary'), role_change=role_change)
+                 role_change=role_change)
         ])
         assert test_candidate.promoted('2019-09-01', date(2020, 1, 1)) is expected_outcome
 
@@ -120,18 +116,18 @@ class TestGrade:
 
 class TestRole:
 
-    @pytest.mark.parametrize("starting_grade, new_grade, temporary, expected_outcome", [
-        ("Grade 7", "Grade 6", False, True),  # substantive promotion
-        ("Grade 7", "Grade 7", None, False),  # level transfer
-        ("Grade 6", "Grade 7", None, False),  # demotion
-        ("Grade 7", "Grade 6", True, True),  # temporary promotion
+    @pytest.mark.parametrize("starting_grade, new_grade, role_change_id, expected_outcome", [
+        ("Grade 7", "Grade 6", 2, True),  # substantive promotion
+        ("Grade 7", "Grade 7", 3, False),  # level transfer
+        ("Grade 6", "Grade 7", 4, False),  # demotion
+        ("Grade 7", "Grade 6", 1, True),  # temporary promotion
     ])
-    def test_is_promotion_returns_correct_values(self, starting_grade, new_grade, temporary, expected_outcome,
+    def test_is_promotion_returns_correct_values(self, starting_grade, new_grade, role_change_id, expected_outcome,
                                                  test_session, test_candidate):
         test_candidate.roles.extend([
             Role(date_started=date(2019, 1, 1), grade=Grade.query.filter_by(value=starting_grade).first(),
-                 temporary_promotion=False),
+                 role_change_id=2),
             Role(date_started=date(2020, 6, 1), grade=Grade.query.filter_by(value=new_grade).first(),
-                 temporary_promotion=temporary)
+                 role_change_id=role_change_id)
         ])
         assert test_candidate.roles[2].is_promotion() is expected_outcome

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -105,7 +105,7 @@ def test_check_details(logged_in_user, test_client, test_session, test_candidate
         sess['new-role'] = {
             'new-grade': higher_grade.id, 'start-date-day': 1, 'start-date-month': 1, 'start-date-year': 2019,
             'new-org': new_org.id, 'new-profession': new_profession.id,
-            'new-location': new_location.id, 'temporary-promotion': 1, 'new-title': 'Senior dev'
+            'new-location': new_location.id, 'new-title': 'Senior dev'
         }
         sess['data-update'] = dict()
         sess['candidate-id'] = test_candidate.id


### PR DESCRIPTION
I've changed the use of Role.temporary_promotion throughout the application. I've left the field on the model for now so I can remove it in a separate PR, so that the deploys are atomic