### PR TITLE
Update search email to use both primary and secondary email

### DIFF
--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -13,6 +13,7 @@ from app.models import (
     Promotion,
 )
 from app.routes import route_blueprint
+from sqlalchemy import or_
 
 
 @route_blueprint.route("/")
@@ -52,9 +53,13 @@ def search_candidate():
         "deferral": "route_blueprint.defer_intake",
     }
     if request.method == "POST":
-        candidate = Candidate.query.filter_by(
-            email_address=request.form.get("candidate-email")
-        ).one_or_none()
+        email = request.form.get("candidate-email")
+        candidate = Candidate.query.filter(
+            or_(
+                Candidate.email_address == email,
+                Candidate.secondary_email_address == email,
+            )
+        ).first()
         if candidate:
             session["candidate-id"] = candidate.id
         else:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -89,6 +89,10 @@ class TestSearchCandidate:
         assert "Most recent candidate email address" in result.data.decode("UTF-8")
 
     @pytest.mark.parametrize(
+        "email",
+        ("test.candidate@numberten.gov.uk", "test.secondary@gov.uk")
+    )
+    @pytest.mark.parametrize(
         "update_type, expected_title",
         [
             ("role", "Role update"),
@@ -104,10 +108,11 @@ class TestSearchCandidate:
         test_candidate,
         logged_in_user,
         test_roles,
+        email
     ):
         with test_client.session_transaction() as sess:
             sess["update-type"] = update_type
-        data = {"candidate-email": "test.candidate@numberten.gov.uk"}
+        data = {"candidate-email": email}
         result = test_client.post(
             "/update/search-candidate",
             data=data,


### PR DESCRIPTION
The email-search field now looks for either the primary or secondary email address on the Candidate. This should help find our pesky candidates faster!