### PR TITLE
Move search to top level and allow users to change candidates email addresses

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,11 +11,11 @@ def create_app(configuration=Config):
     db.init_app(app)
     migrate.init_app(app, db)
     login_manager.init_app(app)
-    login_manager.login_view = "route_blueprint.login"
+    login_manager.login_view = "update_bp.login"
 
-    from app.routes import route_blueprint
+    from app.updates import update_bp
 
-    app.register_blueprint(route_blueprint)
+    app.register_blueprint(update_bp, url_prefix="/update/")
 
     from app.auth import auth_blueprint
 
@@ -28,5 +28,9 @@ def create_app(configuration=Config):
     from app.candidates import candidates_bp
 
     app.register_blueprint(candidates_bp, url_prefix="/candidates/")
+
+    from app.main import main_bp
+
+    app.register_blueprint(main_bp)
 
     return app

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -17,7 +17,7 @@ def login():
 
         next = request.args.get("next")
 
-        return redirect(next or url_for("route_blueprint.hello_world"))
+        return redirect(next or url_for("main_bp.hello_world"))
     return render_template("login.html")
 
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,7 +1,7 @@
 from flask import render_template, request, url_for, redirect
 from app.models import User
 from flask_login import login_user, logout_user
-from flask import flash
+from flask import flash, session
 from app.auth import auth_blueprint
 
 
@@ -24,4 +24,5 @@ def login():
 @auth_blueprint.route("/logout")
 def logout():
     logout_user()
+    session.clear()
     return redirect(url_for("auth_bp.login"))

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,0 +1,6 @@
+from flask import Blueprint
+
+main_bp = Blueprint("main_bp", __name__)
+
+
+from app.main import routes  # noqa: E402,F401

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,0 +1,13 @@
+from app.main import main_bp
+from flask import render_template
+
+
+@main_bp.route("/")
+def hello_world():
+    return render_template("index.html")
+
+
+@main_bp.route("/hello")
+def hello():
+    return "Hello world"
+

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -10,4 +10,3 @@ def hello_world():
 @main_bp.route("/hello")
 def hello():
     return "Hello world"
-

--- a/app/models.py
+++ b/app/models.py
@@ -150,6 +150,26 @@ class Candidate(db.Model):
     def roles_since_date(self, since_date: datetime.date):
         return [role for role in self.roles if role.date_started >= since_date]
 
+    def update_email(self, new_address: str, primary: bool):
+        if primary:
+            self.email_address = new_address
+        elif not primary:
+            self.secondary_email_address = new_address
+
+    def new_role(self, start_date: datetime.date, new_org_id, new_profession_id, new_location_id, new_grade_id, new_title,
+                 role_change_id):
+        self.roles.append(
+            Role(
+                date_started=start_date,
+                organisation_id=new_org_id,
+                profession_id=new_profession_id,
+                location_id=new_location_id,
+                grade_id=new_grade_id,
+                role_name=new_title,
+                role_change_id=role_change_id,
+            )
+        )
+
 
 class Organisation(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/app/models.py
+++ b/app/models.py
@@ -156,8 +156,16 @@ class Candidate(db.Model):
         elif not primary:
             self.secondary_email_address = new_address
 
-    def new_role(self, start_date: datetime.date, new_org_id, new_profession_id, new_location_id, new_grade_id, new_title,
-                 role_change_id):
+    def new_role(
+        self,
+        start_date: datetime.date,
+        new_org_id,
+        new_profession_id,
+        new_location_id,
+        new_grade_id,
+        new_title,
+        role_change_id,
+    ):
         self.roles.append(
             Role(
                 date_started=start_date,

--- a/app/templates/choose-update.html
+++ b/app/templates/choose-update.html
@@ -27,6 +27,12 @@
                     Deferral
                 </label>
             </div>
+            <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="update-type-4" name="update-type" type="radio" value="email">
+                <label class="govuk-label govuk-radios__label" for="update-type-4">
+                    Email
+                </label>
+            </div>
         </div>
         <div class="input submit">
             <input type="submit" value="Submit" class="govuk-button">

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -51,7 +51,7 @@
         <nav>
           <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
             <li class="govuk-header__navigation-item">
-              <a class="govuk-header__link" href="{{ url_for('update_bp.choose_update') }}">
+              <a class="govuk-header__link" href="{{ url_for('update_bp.index') }}">
                 Updates
               </a>
             </li>

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -51,7 +51,7 @@
         <nav>
           <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
             <li class="govuk-header__navigation-item">
-              <a class="govuk-header__link" href="{{ url_for('route_blueprint.choose_update') }}">
+              <a class="govuk-header__link" href="{{ url_for('update_bp.choose_update') }}">
                 Updates
               </a>
             </li>

--- a/app/templates/partials/check-email.html
+++ b/app/templates/partials/check-email.html
@@ -1,0 +1,14 @@
+{% set email_data = data.pop('new-email') %}
+<div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+       New {{ 'primary' if email_data.get('which-email') == 'primary-email' else 'secondary' }} email
+    </dt>
+    <dd class="govuk-summary-list__value">
+        {{ email_data.get('new-address') }}
+    </dd>
+    <dd class="govuk-summary-list__actions">
+        <a class="govuk-link" href="{{ url_for('update_bp.email_address') }}">
+            Change<span class="govuk-visually-hidden"> email</span>
+        </a>
+    </dd>
+</div>

--- a/app/templates/updates/check-your-answers.html
+++ b/app/templates/updates/check-your-answers.html
@@ -17,7 +17,7 @@
                         {{ candidate.email_address }}
                     </dd>
                     <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="{{ url_for('route_blueprint.email_address') }}">
+                        <a class="govuk-link" href="{{ url_for('update_bp.email_address') }}">
                             Change<span class="govuk-visually-hidden"> email</span>
                         </a>
                     </dd>

--- a/app/templates/updates/check-your-answers.html
+++ b/app/templates/updates/check-your-answers.html
@@ -1,5 +1,4 @@
 {% extends 'layout.html' %}
-
 {% block content %}
     <h2 class="govuk-heading-l">
         Check the details you're updating for {{ candidate.first_name }} {{ candidate.last_name }}
@@ -8,24 +7,13 @@
         <div class="govuk-form-group">
             <dl class="govuk-summary-list">
             {% if data.get('new-email') is not none %}
-
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                        Email address
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                        {{ candidate.email_address }}
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="{{ url_for('update_bp.email_address') }}">
-                            Change<span class="govuk-visually-hidden"> email</span>
-                        </a>
-                    </dd>
-                </div>
+                {% include 'partials/check-email.html' %}
              {% endif %}
-                {% for key, value in data.items() %}
+             {% for data_key, data_value in data.items() %}
+                {% for key, value in data_value.items() %}
                     {% include 'partials/summary-section.html' %}
                 {% endfor %}
+            {% endfor %}
             </dl>
         </div>
         <div class="input submit">

--- a/app/templates/updates/complete.html
+++ b/app/templates/updates/complete.html
@@ -1,5 +1,5 @@
 {% extends 'layout.html' %}
 
 {% block content %}
-    Role updated. <a href="{{ url_for('update_bp.choose_update') }}">Another?</a>
+    Successfully updated! <a href="{{ url_for('update_bp.index') }}">Another?</a>
 {% endblock %}

--- a/app/templates/updates/complete.html
+++ b/app/templates/updates/complete.html
@@ -1,5 +1,5 @@
 {% extends 'layout.html' %}
 
 {% block content %}
-    Role updated. <a href="{{ url_for('route_blueprint.choose_update') }}">Another?</a>
+    Role updated. <a href="{{ url_for('update_bp.choose_update') }}">Another?</a>
 {% endblock %}

--- a/app/templates/updates/email-address.html
+++ b/app/templates/updates/email-address.html
@@ -3,35 +3,23 @@
 {% block content %}
     <form class="govuk-form-group" method="post">
         <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" aria-describedby="update-email-address-conditional-hint">
+            <fieldset class="govuk-fieldset" aria-describedby="which-email-address">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                    <h1 class="govuk-fieldset__heading">
-                        Has the candidate got a new email address?
-                    </h1>
+                    <h2 class="govuk-fieldset__heading">
+                        Which of the candidate's email addresses do you want to change?
+                    </h2>
                 </legend>
-                <span id="update-email-address-conditional-hint" class="govuk-hint">
-                    If they have, please supply the new email address
-                </span>
-                <div class="govuk-radios govuk-radios--conditional" data-module="radios">
+                <div class="govuk-radios govuk-radios" data-module="radios">
                     <div class="govuk-radios__item">
-                        <input class="govuk-radios__input" id="update-email-address-conditional-1" name="update-email-address" type="radio" value="true" data-aria-controls="conditional-update-email-address-conditional-1">
-                        <label class="govuk-label govuk-radios__label" for="update-email-address-conditional-1">
-                            Yes
+                        <input class="govuk-radios__input" id="which-email-address-1" name="which-email-address" type="radio" value="primary-email" data-aria-controls="which-email-address-1">
+                        <label class="govuk-label govuk-radios__label" for="which-email-address-1">
+                            Primary email
                         </label>
                     </div>
-                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-update-email-address-conditional-1">
-                        <div class="govuk-form-group">
-                            <label class="govuk-label" for="new-email-address">
-                                Email address
-                            </label>
-                            <input class="govuk-input govuk-!-width-one-third" id="new-email-address" name="new-email-address" type="email" spellcheck="false">
-                        </div>
-
-                    </div>
                     <div class="govuk-radios__item">
-                        <input class="govuk-radios__input" id="update-email-address-conditional-2" name="update-email-address" type="radio" value="false" data-aria-controls="conditional-update-email-address-conditional-2">
-                        <label class="govuk-label govuk-radios__label" for="update-email-address-conditional-2">
-                            No
+                        <input class="govuk-radios__input" id="which-email-address-2" name="which-email-address" type="radio" value="secondary-email" data-aria-controls="which-email-address-2">
+                        <label class="govuk-label govuk-radios__label" for="which-email-address-2">
+                            Secondary email
                         </label>
                     </div>
                 </div>

--- a/app/templates/updates/new-email-address.html
+++ b/app/templates/updates/new-email-address.html
@@ -1,0 +1,32 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+    <form class="govuk-form-group" method="post">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" aria-describedby="update-email-address-conditional-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                    <h1 class="govuk-fieldset__heading">
+                        Has the candidate got a new email address?
+                    </h1>
+                </legend>
+                <div class="govuk-radios govuk-radios--conditional" data-module="radios">
+                    <div class="govuk-radios__item">
+                        <input class="govuk-radios__input" id="update-email-address-1" name="update-email-address" type="radio" value="true" data-aria-controls="update-email-address-1">
+                        <label class="govuk-label govuk-radios__label" for="update-email-address-1">
+                            Yes
+                        </label>
+                    </div>
+                    <div class="govuk-radios__item">
+                        <input class="govuk-radios__input" id="update-email-address-2" name="update-email-address" type="radio" value="false" data-aria-controls="update-email-address-2">
+                        <label class="govuk-label govuk-radios__label" for="update-email-address-2">
+                            No
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="input submit">
+            <input type="submit" value="Continue" class="govuk-button">
+        </div>
+    </form>
+{% endblock %}

--- a/app/templates/updates/update-email-address.html
+++ b/app/templates/updates/update-email-address.html
@@ -1,0 +1,15 @@
+{% extends 'updates/update-layout.html' %}
+    {% block form_content %}
+        <div class="govuk-form-group">
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="email-address">
+                    Updated email address
+                </label>
+                <span id="email-address-hint" class="govuk-hint">
+                    This will replace the candidate's "{{ current_email }}" address
+                </span>
+                <input class="govuk-input" id="email-address" name="email-address" type="text">
+            </div>
+        </div>
+        {% endblock %}
+

--- a/app/updates/__init__.py
+++ b/app/updates/__init__.py
@@ -1,13 +1,13 @@
 from flask import Blueprint, redirect, url_for
 from flask_login import current_user
 
-route_blueprint = Blueprint("route_blueprint", __name__)
+update_bp = Blueprint("update_bp", __name__)
 
 
-@route_blueprint.before_request
+@update_bp.before_request
 def restrict_to_logged_in_users():
     if not current_user.is_authenticated:
         return redirect(url_for("auth_bp.login"))
 
 
-from app.routes import routes  # noqa: E402,F401
+from app.updates import routes  # noqa: E402,F401

--- a/app/updates/routes.py
+++ b/app/updates/routes.py
@@ -43,6 +43,7 @@ def index():
             session["error"] = "That email does not exist"
             return redirect(url_for("update_bp.index"))
         return redirect(url_for("update_bp.choose_update"))
+    session["update-data"] = {}
     return render_template("search-candidate.html", error=session.pop("error", None))
 
 
@@ -72,7 +73,7 @@ def update_role():
         new_role_title = {"new-title": form_as_dict.pop("new-title")[0]}
         new_role_numbers = {key: int(value[0]) for key, value in form_as_dict.items()}
         new_role = {**new_role_numbers, **new_role_title}
-        session["new-role"] = new_role
+        session["update-data"]["new-role"] = new_role
         return redirect(url_for("update_bp.email_address"))
 
     data = {
@@ -100,7 +101,7 @@ def update_name():
 
     if request.method == "POST":
         session["change-route"] = "update_bp.update_name"
-        session["new-name"] = request.form.to_dict(flat=True)
+        session["update-data"]["new-name"] = request.form.to_dict(flat=True)
         return redirect(url_for("update_bp.check_your_answers"))
 
     return render_template(
@@ -118,7 +119,7 @@ def defer_intake():
 
     if request.method == "POST":
         session["change-route"] = "update_bp.defer_intake"
-        session["new-intake-year"] = request.form.get("new-intake-year")
+        session["update-data"]["deferral"] = {"new-intake-year": request.form.get("new-intake-year")}
         return redirect(url_for("update_bp.check_your_answers"))
 
     return render_template(

--- a/app/updates/routes.py
+++ b/app/updates/routes.py
@@ -163,6 +163,7 @@ def update_email():
 
 
 @update_bp.route("/check-your-answers", methods=["POST", "GET"])
+def check_your_answers():
 
     def prettify_string(string_to_prettify):
         string_as_list = list(string_to_prettify)
@@ -192,15 +193,25 @@ def update_email():
     if request.method == "POST":
         post_your_answers()
         return redirect(url_for("update_bp.complete"))
+
+    update_data = session.get('update-data')
+
+    if update_data.get("new-role"):
+        update_data["new-role"] = human_readable_role(update_data.get("new-role"))
+    elif update_data.get("new-name"):
+        update_data["name"] = {
             prettify_string(key): value
-            for key, value in session.get("new-name").items()
+            for key, value in update_data.pop("new-name").items()
         }
-    elif session.get("new-intake-year"):
-        session["data-update"] = {"New intake year": session.get("new-intake-year")}
+    elif update_data.get('deferral'):
+        update_data['deferral'] = {
+            prettify_string(key): value
+            for key, value in update_data.pop("deferral").items()
+        }
     return render_template(
         "updates/check-your-answers.html",
         candidate=candidate,
-        data=session.get("data-update"),
+        data=update_data,
         new_email=session.get("new-email"),
     )
 
@@ -237,6 +248,8 @@ def post_your_answers():
 
     db.session.add(candidate)
     db.session.commit()
+
+
 @update_bp.route("/complete", methods=["GET"])
 def complete():
     return render_template("updates/complete.html")

--- a/app/updates/routes.py
+++ b/app/updates/routes.py
@@ -53,7 +53,7 @@ def choose_update():
         "role": "update_bp.update_role",
         "name": "update_bp.update_name",
         "deferral": "update_bp.defer_intake",
-        "email": "update_bp.new_email_address"
+        "email": "update_bp.new_email_address",
     }
     if request.method == "POST":
         session["update-type"] = request.form.get("update-type")
@@ -119,7 +119,9 @@ def defer_intake():
 
     if request.method == "POST":
         session["change-route"] = "update_bp.defer_intake"
-        session["update-data"]["deferral"] = {"new-intake-year": request.form.get("new-intake-year")}
+        session["update-data"]["deferral"] = {
+            "new-intake-year": request.form.get("new-intake-year")
+        }
         return redirect(url_for("update_bp.check_your_answers"))
 
     return render_template(
@@ -144,7 +146,9 @@ def email_address():
 def new_email_address():
     if request.method == "POST":
         update_data = session["update-data"]
-        update_data["new-email"] = {"which-email": request.form.get("which-email-address")}
+        update_data["new-email"] = {
+            "which-email": request.form.get("which-email-address")
+        }
         session["update-data"] = update_data
         return redirect(url_for("update_bp.update_email"))
     return render_template("updates/email-address.html")
@@ -157,14 +161,21 @@ def update_email():
         update_data["new-email"]["new-address"] = request.form.get("email-address")
         session["update-data"] = update_data
         return redirect(url_for("update_bp.check_your_answers"))
-    candidate = Candidate.query.get(session.get('candidate-id'))
-    current_email = candidate.email_address if session.get('which-email') == 'primary-email' else candidate.secondary_email_address
-    return render_template("updates/update-email-address.html", candidate=candidate, current_email=current_email)
+    candidate = Candidate.query.get(session.get("candidate-id"))
+    current_email = (
+        candidate.email_address
+        if session.get("which-email") == "primary-email"
+        else candidate.secondary_email_address
+    )
+    return render_template(
+        "updates/update-email-address.html",
+        candidate=candidate,
+        current_email=current_email,
+    )
 
 
 @update_bp.route("/check-your-answers", methods=["POST", "GET"])
 def check_your_answers():
-
     def prettify_string(string_to_prettify):
         string_as_list = list(string_to_prettify)
         string_as_list[0] = string_as_list[0].upper()
@@ -194,7 +205,7 @@ def check_your_answers():
         post_your_answers()
         return redirect(url_for("update_bp.complete"))
 
-    update_data = session.get('update-data')
+    update_data = session.get("update-data")
 
     if update_data.get("new-role"):
         update_data["new-role"] = human_readable_role(update_data.get("new-role"))
@@ -203,8 +214,8 @@ def check_your_answers():
             prettify_string(key): value
             for key, value in update_data.pop("new-name").items()
         }
-    elif update_data.get('deferral'):
-        update_data['deferral'] = {
+    elif update_data.get("deferral"):
+        update_data["deferral"] = {
             prettify_string(key): value
             for key, value in update_data.pop("deferral").items()
         }
@@ -228,10 +239,17 @@ def post_your_answers():
     if update_data.get("new-role"):
         role_data = update_data.get("new-role")
         candidate.new_role(
-            start_date=date(role_data["start-date-year"], role_data["start-date-month"], role_data["start-date-day"],),
-            new_org_id=role_data["new-org"], new_profession_id=role_data["new-profession"],
-            new_location_id=role_data["new-location"], new_grade_id=role_data["new-grade"],
-            new_title=role_data["new-title"], role_change_id=role_data["role-change"],
+            start_date=date(
+                role_data["start-date-year"],
+                role_data["start-date-month"],
+                role_data["start-date-day"],
+            ),
+            new_org_id=role_data["new-org"],
+            new_profession_id=role_data["new-profession"],
+            new_location_id=role_data["new-location"],
+            new_grade_id=role_data["new-grade"],
+            new_title=role_data["new-title"],
+            role_change_id=role_data["role-change"],
         )
     elif update_data.get("new-name"):
         name_data = update_data.get("new-name")
@@ -240,8 +258,10 @@ def post_your_answers():
     elif update_data.get("new-intake-year"):
         new_scheme_start_date = date(int(session.pop("new-intake-year")), 3, 1)
         candidate.applications[0].defer(new_scheme_start_date)
-    elif update_data.get('deferral'):
-        candidate.applications.first().defer(date(int(update_data['deferral'].get('new-intake-year')), 3, 1))
+    elif update_data.get("deferral"):
+        candidate.applications.first().defer(
+            date(int(update_data["deferral"].get("new-intake-year")), 3, 1)
+        )
 
     if update_data.get("new-email"):
         new_email_address()

--- a/app/updates/routes.py
+++ b/app/updates/routes.py
@@ -131,9 +131,10 @@ def defer_intake():
 def email_address():
     if request.method == "POST":
         if request.form.get("update-email-address") == "true":
-            session["new-email"] = request.form.get("new-email-address")
-
-        return redirect(url_for("update_bp.check_your_answers"))
+            redirect_target = url_for("update_bp.new_email_address")
+        else:
+            redirect_target = url_for("update_bp.check_your_answers")
+        return redirect(redirect_target)
 
     return render_template("updates/new-email-address.html")
 

--- a/app/updates/routes.py
+++ b/app/updates/routes.py
@@ -159,32 +159,9 @@ def update_email():
     candidate = Candidate.query.get(session.get('candidate-id'))
     current_email = candidate.email_address if session.get('which-email') == 'primary-email' else candidate.secondary_email_address
     return render_template("updates/update-email-address.html", candidate=candidate, current_email=current_email)
-                        role_data["start-date-month"],
-                        role_data["start-date-day"],
-                    ),
-                    organisation_id=role_data["new-org"],
-                    profession_id=role_data["new-profession"],
-                    location_id=role_data["new-location"],
-                    grade_id=role_data["new-grade"],
-                    role_name=role_data["new-title"],
-                    role_change_id=role_data["role-change"],
-                )
-            )
-            new_email = session.get("new-email")
-            if new_email:
-                candidate.email_address = new_email
-        elif session.get("new-name"):
-            name_data = session.pop("new-name")
-            candidate.first_name = name_data.get("first-name")
-            candidate.last_name = name_data.get("last-name")
-        elif session.get("new-intake-year"):
-            new_scheme_start_date = date(int(session.pop("new-intake-year")), 3, 1)
-            candidate.applications[0].defer(new_scheme_start_date)
 
-        db.session.add(candidate)
-        db.session.commit()
 
-        return redirect(url_for("update_bp.complete"))
+@update_bp.route("/check-your-answers", methods=["POST", "GET"])
 
     def prettify_string(string_to_prettify):
         string_as_list = list(string_to_prettify)
@@ -210,10 +187,10 @@ def update_email():
 
         return data
 
-    if session.get("new-role"):
-        session["data-update"] = human_readable_role(session["new-role"])
-    elif session.get("new-name"):
-        session["data-update"] = {
+    candidate = Candidate.query.get(session.get("candidate-id"))
+    if request.method == "POST":
+        post_your_answers()
+        return redirect(url_for("update_bp.complete"))
             prettify_string(key): value
             for key, value in session.get("new-name").items()
         }
@@ -227,6 +204,38 @@ def update_email():
     )
 
 
+def post_your_answers():
+    candidate: Candidate = Candidate.query.get(session.get("candidate-id"))
+    update_data = session.get("update-data")
+
+    def new_email_address():
+        email_data = update_data.get("new-email")
+        primary = True if email_data.get("which-email") == "primary-email" else False
+        candidate.update_email(email_data.get("new-address"), primary)
+
+    if update_data.get("new-role"):
+        role_data = update_data.get("new-role")
+        candidate.new_role(
+            start_date=date(role_data["start-date-year"], role_data["start-date-month"], role_data["start-date-day"],),
+            new_org_id=role_data["new-org"], new_profession_id=role_data["new-profession"],
+            new_location_id=role_data["new-location"], new_grade_id=role_data["new-grade"],
+            new_title=role_data["new-title"], role_change_id=role_data["role-change"],
+        )
+    elif update_data.get("new-name"):
+        name_data = update_data.get("new-name")
+        candidate.first_name = name_data.get("first-name")
+        candidate.last_name = name_data.get("last-name")
+    elif update_data.get("new-intake-year"):
+        new_scheme_start_date = date(int(session.pop("new-intake-year")), 3, 1)
+        candidate.applications[0].defer(new_scheme_start_date)
+    elif update_data.get('deferral'):
+        candidate.applications.first().defer(date(int(update_data['deferral'].get('new-intake-year')), 3, 1))
+
+    if update_data.get("new-email"):
+        new_email_address()
+
+    db.session.add(candidate)
+    db.session.commit()
 @update_bp.route("/complete", methods=["GET"])
 def complete():
     return render_template("updates/complete.html")

--- a/app/updates/routes.py
+++ b/app/updates/routes.py
@@ -55,7 +55,7 @@ def choose_update():
     }
     if request.method == "POST":
         session["update-type"] = request.form.get("update-type")
-        return redirect(url_for(next_steps.get(session.get("update-type"))))
+        return redirect(url_for(next_steps.get(request.form.get("update-type"))))
     return render_template("choose-update.html")
 
 

--- a/app/updates/routes.py
+++ b/app/updates/routes.py
@@ -27,7 +27,7 @@ def results():
     )
 
 
-@update_bp.route("/update", methods=["POST", "GET"])
+@update_bp.route("/", methods=["POST", "GET"])
 def choose_update():
     if request.method == "POST":
         session["update-type"] = request.form.get("update-type")

--- a/app/updates/routes.py
+++ b/app/updates/routes.py
@@ -52,6 +52,7 @@ def choose_update():
         "role": "update_bp.update_role",
         "name": "update_bp.update_name",
         "deferral": "update_bp.defer_intake",
+        "email": "update_bp.new_email_address"
     }
     if request.method == "POST":
         session["update-type"] = request.form.get("update-type")

--- a/app/updates/routes.py
+++ b/app/updates/routes.py
@@ -136,26 +136,29 @@ def email_address():
         else:
             redirect_target = url_for("update_bp.check_your_answers")
         return redirect(redirect_target)
-
     return render_template("updates/new-email-address.html")
 
 
 @update_bp.route("/new-email-address", methods=["POST", "GET"])
 def new_email_address():
+    if request.method == "POST":
+        update_data = session["update-data"]
+        update_data["new-email"] = {"which-email": request.form.get("which-email-address")}
+        session["update-data"] = update_data
+        return redirect(url_for("update_bp.update_email"))
     return render_template("updates/email-address.html")
 
 
-@update_bp.route("/check-your-answers", methods=["POST", "GET"])
-def check_your_answers():
-    candidate = Candidate.query.get(session.get("candidate-id"))
+@update_bp.route("/update-email-address", methods=["POST", "GET"])
+def update_email():
     if request.method == "POST":
-        session.pop("data-update")
-        if session.get("new-role"):
-            role_data = session.pop("new-role", None)
-            candidate.roles.append(
-                Role(
-                    date_started=date(
-                        role_data["start-date-year"],
+        update_data = session["update-data"]
+        update_data["new-email"]["new-address"] = request.form.get("email-address")
+        session["update-data"] = update_data
+        return redirect(url_for("update_bp.check_your_answers"))
+    candidate = Candidate.query.get(session.get('candidate-id'))
+    current_email = candidate.email_address if session.get('which-email') == 'primary-email' else candidate.secondary_email_address
+    return render_template("updates/update-email-address.html", candidate=candidate, current_email=current_email)
                         role_data["start-date-month"],
                         role_data["start-date-day"],
                     ),

--- a/app/updates/routes.py
+++ b/app/updates/routes.py
@@ -28,20 +28,7 @@ def results():
 
 
 @update_bp.route("/", methods=["POST", "GET"])
-def choose_update():
-    if request.method == "POST":
-        session["update-type"] = request.form.get("update-type")
-        return redirect(url_for("update_bp.search_candidate"))
-    return render_template("choose-update.html")
-
-
-@update_bp.route("/search-candidate", methods=["POST", "GET"])
-def search_candidate():
-    next_steps = {
-        "role": "update_bp.update_role",
-        "name": "update_bp.update_name",
-        "deferral": "update_bp.defer_intake",
-    }
+def index():
     if request.method == "POST":
         email = request.form.get("candidate-email")
         candidate = Candidate.query.filter(
@@ -54,16 +41,29 @@ def search_candidate():
             session["candidate-id"] = candidate.id
         else:
             session["error"] = "That email does not exist"
-            return redirect(url_for("update_bp.search_candidate"))
-        return redirect(url_for(next_steps.get(session.get("update-type"))))
+            return redirect(url_for("update_bp.index"))
+        return redirect(url_for("update_bp.choose_update"))
     return render_template("search-candidate.html", error=session.pop("error", None))
+
+
+@update_bp.route("/choose-update", methods=["POST", "GET"])
+def choose_update():
+    next_steps = {
+        "role": "update_bp.update_role",
+        "name": "update_bp.update_name",
+        "deferral": "update_bp.defer_intake",
+    }
+    if request.method == "POST":
+        session["update-type"] = request.form.get("update-type")
+        return redirect(url_for(next_steps.get(session.get("update-type"))))
+    return render_template("choose-update.html")
 
 
 @update_bp.route("/role", methods=["POST", "GET"])
 def update_role():
     candidate_id = session.get("candidate-id")
     if not candidate_id:
-        return redirect(url_for("update_bp.search_candidate"))
+        return redirect(url_for("update_bp.index"))
 
     if request.method == "POST":
         session["change-route"] = "update_bp.update_role"
@@ -95,7 +95,7 @@ def update_role():
 def update_name():
     candidate_id = session.get("candidate-id")
     if not candidate_id:
-        return redirect(url_for("update_bp.search_candidate"))
+        return redirect(url_for("update_bp.index"))
 
     if request.method == "POST":
         session["change-route"] = "update_bp.update_name"
@@ -113,7 +113,7 @@ def update_name():
 def defer_intake():
     candidate_id = session.get("candidate-id")
     if not candidate_id:
-        return redirect(url_for("update_bp.search_candidate"))
+        return redirect(url_for("update_bp.index"))
 
     if request.method == "POST":
         session["change-route"] = "update_bp.defer_intake"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -166,7 +166,8 @@ def test_check_details(
     new_location = Location.query.first()
     role_change = Promotion.query.first()
     with test_client.session_transaction() as sess:
-        sess["new-role"] = {
+        sess["update-data"] = {}
+        sess["update-data"]["new-role"] = {
             "new-grade": higher_grade.id,
             "start-date-day": 1,
             "start-date-month": 1,
@@ -177,13 +178,17 @@ def test_check_details(
             "new-location": new_location.id,
             "new-title": "Senior dev",
         }
-        sess["data-update"] = dict()
+        sess["update-data"]["new-email"] = {
+            "new-address": "changed_address@gov.uk",
+            "which-email": "primary-email"
+        }
         sess["candidate-id"] = test_candidate.id
     test_client.post("/update/check-your-answers")
     latest_role: Role = test_candidate.roles.order_by(Role.id.desc()).first()
     assert "Organisation 1" == Organisation.query.get(latest_role.organisation_id).name
     assert "Senior dev" == latest_role.role_name
     assert "substantive promotion" == latest_role.role_change.value
+    assert "changed_address@gov.uk" == test_candidate.email_address
 
 
 class TestAuthentication:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -31,21 +31,29 @@ class TestNewEmail:
 
         with test_client.session_transaction() as sess:
             sess["candidate-id"] = 1
-        data = {
-            "update-email-address": "true",
-        }
-        result = test_client.post(url_for("update_bp.email_address"), data=data, follow_redirects=True)
-        assert "Which of the candidate's email addresses do you want to change?" in result.data.decode('UTF-8')
+        data = {"update-email-address": "true"}
+        result = test_client.post(
+            url_for("update_bp.email_address"), data=data, follow_redirects=True
+        )
+        assert (
+            "Which of the candidate's email addresses do you want to change?"
+            in result.data.decode("UTF-8")
+        )
 
     def test_post_no_new_address(self, test_client, logged_in_user):
         with test_client.session_transaction() as sess:
             sess["candidate-id"] = 1
-        data = {
-            "update-email-address": "false",
-        }
-        result = test_client.post("/update/email-address", data=data, follow_redirects=False,
-                                  headers={"content-type": "application/x-www-form-urlencoded"},)
-        assert result.location == f"http://localhost{url_for('update_bp.check_your_answers')}"
+        data = {"update-email-address": "false"}
+        result = test_client.post(
+            "/update/email-address",
+            data=data,
+            follow_redirects=False,
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+        assert (
+            result.location
+            == f"http://localhost{url_for('update_bp.check_your_answers')}"
+        )
 
 
 class TestUpdateType:
@@ -61,12 +69,18 @@ class TestUpdateType:
             ("role", "update_role"),
             ("name", "update_name"),
             ("deferral", "defer_intake"),
-        ]
+        ],
     )
-    def test_post_returns_correct_destination(self, option, destination, test_client, logged_in_user, test_session):
-        destination_url = url_for(f'update_bp.{destination}')
-        result = test_client.post(url_for("update_bp.choose_update"), data={"update-type": option},
-                                  follow_redirects=False, headers={"content-type": "application/x-www-form-urlencoded"})
+    def test_post_returns_correct_destination(
+        self, option, destination, test_client, logged_in_user, test_session
+    ):
+        destination_url = url_for(f"update_bp.{destination}")
+        result = test_client.post(
+            url_for("update_bp.choose_update"),
+            data={"update-type": option},
+            follow_redirects=False,
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
         assert result.location == f"http://localhost{destination_url}"
 
 
@@ -116,17 +130,9 @@ class TestSearchCandidate:
         assert "Most recent candidate email address" in result.data.decode("UTF-8")
 
     @pytest.mark.parametrize(
-        "email",
-        ("test.candidate@numberten.gov.uk", "test.secondary@gov.uk")
+        "email", ("test.candidate@numberten.gov.uk", "test.secondary@gov.uk")
     )
-    def test_post(
-        self,
-        test_client,
-        test_candidate,
-        logged_in_user,
-        test_roles,
-        email
-    ):
+    def test_post(self, test_client, test_candidate, logged_in_user, test_roles, email):
         data = {"candidate-email": email}
         test_client.post(
             "/update/",
@@ -148,10 +154,7 @@ class TestSearchCandidate:
             headers={"content-type": "application/x-www-form-urlencoded"},
         )
         assert result.status_code == 302
-        assert (
-            result.location
-            == f"http://localhost{url_for('update_bp.index')}"
-        )
+        assert result.location == f"http://localhost{url_for('update_bp.index')}"
 
 
 def test_check_details(
@@ -183,7 +186,7 @@ def test_check_details(
         }
         sess["update-data"]["new-email"] = {
             "new-address": "changed_address@gov.uk",
-            "which-email": "primary-email"
+            "which-email": "primary-email",
         }
         sess["candidate-id"] = test_candidate.id
     test_client.post("/update/check-your-answers")
@@ -199,12 +202,7 @@ class TestAuthentication:
         assert current_user.is_authenticated
 
     @pytest.mark.parametrize(
-        "url",
-        [
-            "/update/",
-            "/reports/",
-            "/candidates/candidate/1",
-        ],
+        "url", ["/update/", "/reports/", "/candidates/candidate/1"]
     )
     def test_non_logged_in_users_are_redirected_to_login(self, url, test_client):
         with test_client:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -42,7 +42,7 @@ class TestNewEmail:
 class TestUpdateType:
     @pytest.mark.parametrize("option", ["Role", "Name", "Deferral"])
     def test_get(self, option, test_client, logged_in_user):
-        result = test_client.get(url_for("route_blueprint.choose_update"))
+        result = test_client.get(url_for("update_bp.choose_update"))
         assert option in result.data.decode("UTF-8")
 
 
@@ -139,7 +139,7 @@ class TestSearchCandidate:
         assert result.status_code == 302
         assert (
             result.location
-            == f"http://localhost{url_for('route_blueprint.search_candidate')}"
+            == f"http://localhost{url_for('update_bp.search_candidate')}"
         )
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -49,10 +49,25 @@ class TestNewEmail:
 
 
 class TestUpdateType:
-    @pytest.mark.parametrize("option", ["Role", "Name", "Deferral"])
+    @pytest.mark.parametrize("option", ["Role", "Name", "Deferral", "Email"])
     def test_get(self, option, test_client, logged_in_user):
         result = test_client.get(url_for("update_bp.choose_update"))
         assert option in result.data.decode("UTF-8")
+
+    @pytest.mark.parametrize(
+        "option, destination",
+        [
+            ("email", "new_email_address"),
+            ("role", "update_role"),
+            ("name", "update_name"),
+            ("deferral", "defer_intake"),
+        ]
+    )
+    def test_post_returns_correct_destination(self, option, destination, test_client, logged_in_user, test_session):
+        destination_url = url_for(f'update_bp.{destination}')
+        result = test_client.post(url_for("update_bp.choose_update"), data={"update-type": option},
+                                  follow_redirects=False, headers={"content-type": "application/x-www-form-urlencoded"})
+        assert result.location == f"http://localhost{destination_url}"
 
 
 class TestRoleUpdate:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -103,8 +103,11 @@ class TestRoleUpdate:
             "role-change": "1",
             "new-title": "Senior dev",
         }
-        test_client.post("/update/role", data=data)
-        assert data.keys() == session.get("new-role").keys()
+        with test_client.session_transaction() as sess:
+            sess["update-data"] = {}
+            sess["candidate-id"] = test_candidate.id
+        test_client.post("/update/role", data=data, follow_redirects=False)
+        assert data.keys() == session.get("update-data").get("new-role").keys()
 
 
 class TestSearchCandidate:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -126,7 +126,7 @@ class TestSearchCandidate:
     ):
         data = {"candidate-email": email}
         test_client.post(
-            "/update/search-candidate",
+            "/update/",
             data=data,
             follow_redirects=True,
             headers={"content-type": "application/x-www-form-urlencoded"},

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -27,16 +27,25 @@ class TestNewEmail:
         result = test_client.get("/update/email-address")
         assert b"Has the candidate got a new email address?" in result.data
 
-    def test_post(self, test_client, logged_in_user, test_candidate):
+    def test_post_new_address(self, test_client, logged_in_user, test_candidate):
 
         with test_client.session_transaction() as sess:
             sess["candidate-id"] = 1
         data = {
             "update-email-address": "true",
-            "new-email-address": "new-test-email@gov.uk",
         }
-        test_client.post("/update/email-address", data=data)
-        assert "new-test-email@gov.uk" == session.get("new-email")
+        result = test_client.post("/update/email-address", data=data, follow_redirects=True)
+        assert "Which of the candidate's email addresses do you want to change?" in result.data.decode('UTF-8')
+
+    def test_post_no_new_address(self, test_client, logged_in_user):
+        with test_client.session_transaction() as sess:
+            sess["candidate-id"] = 1
+        data = {
+            "update-email-address": "false",
+        }
+        result = test_client.post("/update/email-address", data=data, follow_redirects=False,
+                                  headers={"content-type": "application/x-www-form-urlencoded"},)
+        assert result.location == f"http://localhost{url_for('update_bp.check_your_answers')}"
 
 
 class TestUpdateType:


### PR DESCRIPTION
This is really too big so I'll do my best to explain this logically. There's a small interface change that has been very difficult to achieve, some updates to the user journey, and a big change at the backend.

1. First: users now search for candidates as the first action, rather than the second. This makes moving through the interface smoother and more in line with what we'd expect.
2. Users can now change a candidate's email address without needing to change their role at the same time - many thanks to Victoria who uncovered this user need
3. All of the update data is passed into the session as a dictionary and then converted into objects at the end. There were some struggles until I remembered that the `session` is an `ImmutableDict` and therefore, well, immutable.