### PR TITLE
Add role title to the candidate profile page

### DIFF
--- a/app/templates/partials/accordion-section-role.html
+++ b/app/templates/partials/accordion-section-role.html
@@ -2,7 +2,7 @@
     <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
             <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-              Database Analyst - Home Office
+              {{ role.role_name }}
             </span>
         </h2>
     </div>


### PR DESCRIPTION
A very small change - I had previously hard-coded a role title into the profile page. I've also tweaked the `candidates` blueprint - `candidates/candidate/<candidate_id>` was a bit lengthy so I've cut it back to `candidates/<candidate_id>`