### PR TITLE
Update profile page to show first and current role

### DIFF
--- a/app/templates/candidates/profile.html
+++ b/app/templates/candidates/profile.html
@@ -33,7 +33,10 @@
         </div>
       </div>
         {% for role in candidate.roles %}
-            {% include 'partials/accordion-section-role.html' %}
+            {% with first=loop.first, last=loop.last %}
+                {% include 'partials/accordion-section-role.html' %}
+            {% endwith %}
+
         {% endfor %}
     </div>
 

--- a/app/templates/partials/accordion-section-role.html
+++ b/app/templates/partials/accordion-section-role.html
@@ -2,7 +2,12 @@
     <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
             <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-              {{ role.role_name }}
+                {% if first %}
+                    Current role:
+                {% elif last %}
+                    First role:
+                {% endif %}
+            {{ role.role_name }}
             </span>
         </h2>
     </div>


### PR DESCRIPTION
I've made this change based on user feedback. As the initial dataset contains only the grade participants started at and their current roles, there was concern that some people might seem to have jumped significantly without any intervening roles. This change makes it clear that there was a gap!

I'm passing the 'first' and 'last' boolean variables on the loop to the template, so that it knows whether the role is the most recent or earliest. Kudos to Pallets for including that extremely helpful little counter, by the way. It means I can dynamically set which is the participants latest, versus earliest, role.

Before and after shots!
<img width="1008" alt="Screen Shot 2019-10-12 at 10 36 15" src="https://user-images.githubusercontent.com/3410350/66699157-2f2dc600-ecdc-11e9-854a-e66b6b9754ca.png">

<img width="1040" alt="Screen Shot 2019-10-12 at 10 35 56" src="https://user-images.githubusercontent.com/3410350/66699156-2f2dc600-ecdc-11e9-94df-10c401ecdaaf.png">

