### PR TITLE
Remove testing database at the end of the test run

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -36,6 +36,7 @@ def db(test_client):
     yield _db
 
     _db.drop_all()
+    os.remove("/home/jonathan/projects/talent-tracker/app/testing-database")
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
A small tweak to remove the test database. This makes the repo smaller and removes the risk of accidentally committing the db into the repo.