### PR TITLE
Fix error when running promotion report

### DIFF
--- a/app/templates/reports/promotion-report.html
+++ b/app/templates/reports/promotion-report.html
@@ -42,7 +42,7 @@
                 </select>
             </div>
         </div>
-
+        <input type="hidden" name="report-type" value="promotions">
         <div class="input submit">
             <input type="submit" value="Generate report" class="govuk-button">
         </div>


### PR DESCRIPTION
My tests worked, because my tests were wrong. The API expected a key-value pair for "report-type", and although I supplied it in the test I didn't supply it in the app. I've added it to the form as a hidden value, but I wonder if it's necessary - and if it is, how I can get some end-to-end tests running to catch this sort of thing.