### PR TITLE
Clean up promotions

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -88,6 +88,7 @@ class Candidate(db.Model):
         order_by="Application.scheme_start_date.desc()",
     )
     joining_grade = db.relationship("Grade", backref="candidate")
+    role_changes = db.relationship("RoleChangeEvent", backref="candidate")
 
     def __repr__(self):
         return f"<Candidate email {self.email_address}>"
@@ -175,6 +176,15 @@ class Candidate(db.Model):
                 grade_id=new_grade_id,
                 role_name=new_title,
                 role_change_id=role_change_id,
+            )
+        )
+        self.role_changes.append(
+            RoleChangeEvent(
+                candidate_id=self.id,
+                former_role_id=self.roles[1].id,
+                new_role_id=self.roles[0].id,
+                role_change_id=role_change_id,
+                role_change_date=start_date,
             )
         )
 

--- a/conftest.py
+++ b/conftest.py
@@ -248,11 +248,16 @@ def candidates_promoter():
         for candidate in candidates_to_promote[
             0 : int(len(candidates_to_promote) * decimal_ratio)
         ]:
-            candidate.roles.extend(
-                [
-                    Role(date_started=date(2018, 1, 1)),
-                    Role(date_started=date(2019, 3, 1), role_change=change_type),
-                ]
+            candidate.roles.append(Role(date_started=date(2018, 1, 1)))
+            candidate: Candidate
+            candidate.new_role(
+                start_date=date(2019, 3, 1),
+                new_org_id=1,
+                new_profession_id=1,
+                new_location_id=1,
+                new_grade_id=1,
+                new_title="New title",
+                role_change_id=change_type.id,
             )
         return candidates_to_promote
 

--- a/conftest.py
+++ b/conftest.py
@@ -68,8 +68,8 @@ def test_session(blank_session):
     blank_session.add_all([Scheme(id=1, name="FLS"), Scheme(id=2, name="SLS")])
     blank_session.add_all(
         [
-            Promotion(id=1, value="substantive promotion"),
-            Promotion(id=2, value="temporary promotion"),
+            Promotion(id=1, value="temporary"),
+            Promotion(id=2, value="substantive"),
             Promotion(id=3, value="level transfer"),
             Promotion(id=4, value="demotion"),
         ]
@@ -240,12 +240,10 @@ def disability_with_without_no_answer(test_session):
 def candidates_promoter():
     def _promoter(candidates_to_promote, decimal_ratio, temporary=False):
         if temporary:
-            change_type = Promotion.query.filter(
-                Promotion.value == "temporary promotion"
-            ).first()
+            change_type = Promotion.query.filter(Promotion.value == "temporary").first()
         else:
             change_type = Promotion.query.filter(
-                Promotion.value == "substantive promotion"
+                Promotion.value == "substantive"
             ).first()
         for candidate in candidates_to_promote[
             0 : int(len(candidates_to_promote) * decimal_ratio)

--- a/reporting/base_promotion_report.py
+++ b/reporting/base_promotion_report.py
@@ -75,7 +75,9 @@ class PromotionReport(Report, ABC):
         return [
             candidate
             for candidate in candidates
-            if candidate.promoted(self.promotions_count_from, temporary=temporary)
+            if candidate.promoted_between(
+                self.promotions_count_from, temporary=temporary
+            )
         ]
 
     def write_row(self, row_data, data_object, csv_writer):

--- a/reporting/reports.py
+++ b/reporting/reports.py
@@ -131,7 +131,7 @@ class PromotionReport(Report, ABC):
         return [
             candidate
             for candidate in candidates
-            if candidate.promoted(self.promoted_before_date, temporary)
+            if candidate.promoted_between(self.promoted_before_date, temporary)
         ]
 
     def write_row(self, row_data, data_object, csv_writer):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -49,7 +49,7 @@ class TestCandidate:
                     {
                         "date-started": date(2019, 12, 1),
                         "grade-value": "Grade 6",
-                        "role-change": "substantive promotion",
+                        "role-change": "substantive",
                     },
                 ],
                 True,
@@ -60,7 +60,7 @@ class TestCandidate:
                     {
                         "date-started": date(2019, 12, 1),
                         "grade-value": "Grade 6",
-                        "role-change": "temporary promotion",
+                        "role-change": "temporary",
                     },
                 ],
                 False,
@@ -82,7 +82,7 @@ class TestCandidate:
                     {
                         "date-started": date(2020, 3, 1),
                         "grade-value": "Grade 6",
-                        "role-change": "substantive promotion",
+                        "role-change": "substantive",
                     },
                 ],
                 False,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -107,22 +107,26 @@ class TestCandidate:
             value=list_of_role_data[1].get("role-change")
         ).first()
         test_candidate: Candidate
-        test_candidate.roles.extend(
-            [
-                Role(
-                    date_started=list_of_role_data[0].get("date-started"),
-                    grade=Grade.query.filter_by(
-                        value=list_of_role_data[0].get("grade-value")
-                    ).first(),
-                ),
-                Role(
-                    date_started=list_of_role_data[1].get("date-started"),
-                    grade=Grade.query.filter_by(
-                        value=list_of_role_data[1].get("grade-value")
-                    ).first(),
-                    role_change=role_change,
-                ),
-            ]
+        test_candidate.roles.append(
+            Role(
+                date_started=list_of_role_data[0].get("date-started"),
+                grade=Grade.query.filter_by(
+                    value=list_of_role_data[0].get("grade-value")
+                ).first(),
+            )
+        )
+        test_candidate.new_role(
+            start_date=list_of_role_data[1].get("date-started"),
+            new_org_id=1,
+            new_profession_id=1,
+            new_location_id=1,
+            new_grade_id=Grade.query.filter_by(
+                value=list_of_role_data[1].get("grade-value")
+            )
+            .first()
+            .id,
+            new_title="New title",
+            role_change_id=role_change.id,
         )
         assert (
             test_candidate.promoted("2019-09-01", date(2020, 1, 1)) is expected_outcome

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -129,7 +129,8 @@ class TestCandidate:
             role_change_id=role_change.id,
         )
         assert (
-            test_candidate.promoted("2019-09-01", date(2020, 1, 1)) is expected_outcome
+            test_candidate.promoted_between("2019-09-01", date(2020, 1, 1))
+            is expected_outcome
         )
 
     def test_current_scheme_returns_current_scheme(self, test_candidate_applied_to_fls):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,5 +1,6 @@
 import pytest
 from flask import url_for, session
+from datetime import date
 
 from app.models import (
     Grade,
@@ -9,6 +10,7 @@ from app.models import (
     Role,
     AuditEvent,
     Promotion,
+    RoleChangeEvent,
 )
 from flask_login import current_user
 
@@ -209,6 +211,11 @@ def test_check_details(
     assert "Senior dev" == latest_role.role_name
     assert "substantive promotion" == latest_role.role_change.value
     assert "changed_address@gov.uk" == test_candidate.email_address
+
+    assert len(RoleChangeEvent.query.all()) == 1
+    role_change_event: RoleChangeEvent = RoleChangeEvent.query.first()
+    assert role_change_event.new_role_id == latest_role.id
+    assert role_change_event.role_change_date == date(2019, 1, 1)
 
 
 class TestAuthentication:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -186,7 +186,7 @@ def test_check_details(
     new_org = Organisation.query.first()
     new_profession = Profession.query.first()
     new_location = Location.query.first()
-    role_change = Promotion.query.first()
+    role_change = Promotion.query.filter_by(value="substantive").first()
     with test_client.session_transaction() as sess:
         sess["update-data"] = {}
         sess["update-data"]["new-role"] = {
@@ -209,7 +209,7 @@ def test_check_details(
     latest_role: Role = test_candidate.roles.order_by(Role.id.desc()).first()
     assert "Organisation 1" == Organisation.query.get(latest_role.organisation_id).name
     assert "Senior dev" == latest_role.role_name
-    assert "substantive promotion" == latest_role.role_change.value
+    assert "substantive" == latest_role.role_change.value
     assert "changed_address@gov.uk" == test_candidate.email_address
 
     assert len(RoleChangeEvent.query.all()) == 1


### PR DESCRIPTION
This PR improves the way the application examines and calculates role changes. It uses the new RoleChangeEvent introduced in #271 to calculate what role changes a candidate has undergone, and if any of those are promotions. While there, I cleaned up the way the tests operated so that they interacted with the Candidate API as the application does. This broke some tests, which was good, as they obviously weren't testing the right things.

The next thing to do will be delete the unnecessary columns from the Role table and see what breaks. Hopefully nothing :crossed_fingers: 