### PR TITLE
Improve use of Role

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -179,12 +179,13 @@ class Candidate(db.Model):
         self.role_changes.append(
             RoleChangeEvent(
                 candidate_id=self.id,
-                former_role_id=self.roles[1].id,
+                former_role_id=self.roles[1].id if len(self.roles.all()) > 1 else None,
                 new_role_id=self.roles[0].id,
                 role_change_id=role_change_id,
                 role_change_date=start_date,
             )
         )
+        db.session.commit()
 
 
 class Organisation(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -177,27 +177,25 @@ class Candidate(db.Model):
         new_title,
         role_change_id,
     ):
-        self.roles.append(
-            Role(
-                date_started=start_date,
-                organisation_id=new_org_id,
-                profession_id=new_profession_id,
-                location_id=new_location_id,
-                grade_id=new_grade_id,
-                role_name=new_title,
-                role_change_id=role_change_id,
-            )
+        new_role = Role(
+            organisation_id=new_org_id,
+            profession_id=new_profession_id,
+            location_id=new_location_id,
+            grade_id=new_grade_id,
+            role_name=new_title,
         )
+        self.roles.append(new_role)
         self.role_changes.append(
             RoleChangeEvent(
                 candidate_id=self.id,
-                former_role_id=self.roles[1].id if len(self.roles.all()) > 1 else None,
-                new_role_id=self.roles[0].id,
+                former_role_id=None
+                if self.current_role() is None
+                else self.current_role().id,
+                new_role_id=new_role.id,
                 role_change_id=role_change_id,
                 role_change_date=start_date,
             )
         )
-        db.session.commit()
 
 
 class Organisation(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -43,6 +43,18 @@ def load_user(id):
     return User.query.get(int(id))
 
 
+class RoleChangeEvent(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    role_change_date = db.Column(db.Date())
+
+    candidate_id = db.Column(db.ForeignKey("candidate.id"))
+    former_role_id = db.Column(db.ForeignKey("role.id"))
+    new_role_id = db.Column(db.ForeignKey("role.id"))
+    role_change_id = db.Column(db.ForeignKey("promotion.id"))
+
+    role_change = db.relationship("Promotion", lazy="select")
+
+
 class Ethnicity(CandidateGetterMixin, db.Model):
     """
     The ethnicity table has a boolean flag for bame, allowing us to query candidates (and therefore data connected to
@@ -400,13 +412,3 @@ class AuditEvent(db.Model):
 class Promotion(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     value = db.Column(db.String(28), index=True)
-
-
-class RoleChangeEvent(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    role_change_date = db.Column(db.Date())
-
-    candidate_id = db.Column(db.ForeignKey("candidate.id"))
-    former_role_id = db.Column(db.ForeignKey("role.id"))
-    new_role_id = db.Column(db.ForeignKey("role.id"))
-    role_change_id = db.Column(db.ForeignKey("promotion.id"))

--- a/app/models.py
+++ b/app/models.py
@@ -158,8 +158,10 @@ class Candidate(db.Model):
     def current_location(self):
         return self.current_role().location.value
 
-    def roles_since_date(self, since_date: datetime.date):
-        return [role for role in self.roles if role.date_started >= since_date]
+    def role_change_events_since_date(self, since_date: datetime.date):
+        return self.role_changes.filter(
+            RoleChangeEvent.role_change_date >= since_date
+        ).all()
 
     def update_email(self, new_address: str, primary: bool):
         if primary:

--- a/app/models.py
+++ b/app/models.py
@@ -108,7 +108,7 @@ class Candidate(db.Model):
         return f"<Candidate email {self.email_address}>"
 
     def current_grade(self) -> "Grade":
-        return self.roles.order_by(Role.date_started.desc()).first().grade
+        return self.current_role().grade
 
     def promoted_between(
         self,
@@ -156,7 +156,7 @@ class Candidate(db.Model):
         )
 
     def current_location(self):
-        return self.roles.order_by(Role.id.desc()).first().location.value
+        return self.current_role().location.value
 
     def roles_since_date(self, since_date: datetime.date):
         return [role for role in self.roles if role.date_started >= since_date]

--- a/app/models.py
+++ b/app/models.py
@@ -167,6 +167,12 @@ class Candidate(db.Model):
         elif not primary:
             self.secondary_email_address = new_address
 
+    def current_role(self):
+        if self.role_changes.first() is None:
+            return None
+        else:
+            return Role.query.get(self.role_changes.first().new_role_id)
+
     def new_role(
         self,
         start_date: datetime.date,

--- a/conftest.py
+++ b/conftest.py
@@ -129,27 +129,75 @@ def test_candidate(test_session):
 
 
 @pytest.fixture
-def test_candidate_applied_to_fls(test_candidate, test_session):
-    test_candidate.applications.append(
+def detailed_candidate(test_candidate: Candidate, test_session):
+    test_candidate: Candidate
+    test_session.add(Organisation(id=1, name="Department of Fun"))
+    test_session.add(Location(id=2, value="Stargate-1"))
+    test_session.add(WorkingPattern(id=1, value="24/7"))
+    test_session.add(Belief(id=1, value="Don't forget to be awesome"))
+    test_session.add(Sexuality(id=1, value="Pan"))
+    test_session.add(Ethnicity(id=1, value="Terran", bame=True))
+    test_session.add_all(
+        [
+            Gender(id=1, value="Fork"),
+            Gender(id=2, value="Knife"),
+            Gender(id=3, value="Chopsticks"),
+        ]
+    )
+    test_session.add(Grade(id=5, value="Director (SCS2)", rank=3))
+    test_session.add(
+        MainJobType(id=1, value="Roboticist", lower_socio_economic_background=True)
+    )
+    test_session.add(AgeRange(id=1, value="Immortal"))
+
+    test_candidate.joining_date = date(2017, 9, 1)
+    test_candidate.joining_grade_id = 1
+    test_candidate.main_job_type_id = 1
+    test_candidate.working_pattern_id = 1
+    test_candidate.belief_id = 1
+    test_candidate.age_range_id = 1
+    test_candidate.caring_responsibility = True
+    test_candidate.long_term_health_condition = True
+
+    test_session.add(test_candidate)
+    test_session.commit()
+
+    yield Candidate.query.get(1)
+
+
+@pytest.fixture
+def test_candidate_applied_to_fls(detailed_candidate, test_session):
+    detailed_candidate.applications.append(
         Application(
-            application_date=date(2019, 6, 1),
+            application_date=date(2018, 6, 1),
             scheme_id=1,
-            scheme_start_date=date(2020, 3, 1),
+            scheme_start_date=date(2019, 3, 1),
+            cohort=1,
+            meta=True,
+            delta=False,
         )
     )
-    test_session.add(test_candidate)
+    test_session.add(detailed_candidate)
     test_session.commit()
     yield Candidate.query.first()
 
 
 @pytest.fixture
-def test_candidate_applied_and_promoted(test_candidate_applied_to_fls, test_session):
-    test_candidate_applied_to_fls.roles.append(
-        Role(date_started=date(2020, 1, 1), role_change_id=2)
+def test_candidate_applied_and_promoted(
+    test_candidate_applied_to_fls: Candidate, test_session
+):
+    test_candidate_applied_to_fls.new_role(
+        start_date=date(2019, 6, 1),
+        new_org_id=1,
+        new_profession_id=1,
+        new_location_id=2,
+        new_grade_id=5,
+        new_title="Director of Happiness",
+        role_change_id=2,
     )
     test_session.add(test_candidate_applied_to_fls)
     test_session.commit()
-    yield
+    yield Candidate.query.first()
 
 
 @pytest.fixture
@@ -287,58 +335,6 @@ def scheme_appender(test_session):
             )
 
     return _add_scheme
-
-
-@pytest.fixture
-def detailed_candidate(test_candidate: Candidate, test_session):
-    test_candidate: Candidate
-    test_session.add(Organisation(id=1, name="Department of Fun"))
-    test_session.add(Location(id=2, value="Stargate-1"))
-    test_session.add(WorkingPattern(id=1, value="24/7"))
-    test_session.add(Belief(id=1, value="Don't forget to be awesome"))
-    test_session.add(Sexuality(id=1, value="Pan"))
-    test_session.add(Ethnicity(id=1, value="Terran", bame=True))
-    test_session.add_all(
-        [
-            Gender(id=1, value="Fork"),
-            Gender(id=2, value="Knife"),
-            Gender(id=3, value="Chopsticks"),
-        ]
-    )
-    test_session.add(Grade(id=5, value="Director (SCS2)", rank=3))
-    test_session.add(
-        MainJobType(id=1, value="Roboticist", lower_socio_economic_background=True)
-    )
-    test_session.add(AgeRange(id=1, value="Immortal"))
-
-    test_candidate.joining_date = date(2018, 9, 1)
-    test_candidate.joining_grade_id = 1
-    test_candidate.main_job_type_id = 1
-    test_candidate.working_pattern_id = 1
-    test_candidate.belief_id = 1
-    test_candidate.age_range_id = 1
-    test_candidate.caring_responsibility = True
-    test_candidate.long_term_health_condition = True
-
-    test_candidate.applications.append(
-        Application(
-            application_date=date(2018, 6, 1),
-            scheme_start_date=date(2019, 3, 1),
-            meta=True,
-            delta=False,
-            cohort=1,
-            scheme_id=1,
-        )
-    )
-    test_candidate.new_role(
-        start_date=date(2019, 6, 1),
-        new_org_id=1,
-        new_profession_id=1,
-        new_location_id=2,
-        new_grade_id=5,
-        new_title="Director of Happiness",
-        role_change_id=1,
-    )
 
 
 @pytest.fixture

--- a/reporting/detailed_report.py
+++ b/reporting/detailed_report.py
@@ -94,10 +94,12 @@ class DetailedReport(Report):
         return [
             candidate
             for candidate in self.eligible_candidates()
-            if self.role_change_type
+            if self.role_change_type.id
             in {
-                role.role_change
-                for role in candidate.roles_since_date(date(self.intake, 1, 1))
+                rce.role_change_id
+                for rce in candidate.role_change_events_since_date(
+                    date(self.intake, 1, 1)
+                )
             }
         ]
 

--- a/reporting/detailed_report.py
+++ b/reporting/detailed_report.py
@@ -51,7 +51,7 @@ class DetailedReport(Report):
 
     def row_writer(self, candidate: Candidate) -> List:
         application = candidate.most_recent_application()
-        current_role: Role = candidate.roles[0]
+        current_role: Role = candidate.current_role()
         return [
             f"{candidate.first_name} {candidate.last_name}",
             candidate.email_address,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,17 +28,8 @@ def test_fls_questions_create_leadership_record(test_session):
 
 class TestCandidate:
     def test_current_grade_returns_correct_grade(self, test_candidate, test_session):
-        grades = Grade.query.order_by(Grade.rank.asc()).all()
-        roles = [
-            Role(date_started=date(2017 + i, 1, 1), grade=grades[i]) for i in range(3)
-        ]
-        test_candidate.roles.extend(roles)
-        test_session.add(test_candidate)
-        test_session.commit()
-        assert (
-            Candidate.query.get(test_candidate.id).current_grade().value
-            == "Deputy Director (SCS1)"
-        )
+
+        assert Candidate.query.get(test_candidate.id).current_grade().value == "Grade 7"
 
     @pytest.mark.parametrize(
         "list_of_role_data, expected_outcome",
@@ -139,7 +130,7 @@ class TestCandidate:
     @pytest.mark.parametrize(
         "prior_application, expected_output",
         [
-            (Application(application_date=date(2018, 6, 1)), date(2019, 6, 1)),
+            (Application(application_date=date(2017, 6, 1)), date(2018, 6, 1)),
             (Application(application_date=date(2020, 6, 1)), date(2020, 6, 1)),
         ],
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -184,20 +184,24 @@ class TestRole:
         role_change_id,
         expected_outcome,
         test_session,
-        test_candidate,
+        test_candidate: Candidate,
     ):
-        test_candidate.roles.extend(
-            [
-                Role(
-                    date_started=date(2019, 1, 1),
-                    grade=Grade.query.filter_by(value=starting_grade).first(),
-                    role_change_id=2,
-                ),
-                Role(
-                    date_started=date(2020, 6, 1),
-                    grade=Grade.query.filter_by(value=new_grade).first(),
-                    role_change_id=role_change_id,
-                ),
-            ]
+        test_candidate.new_role(
+            start_date=date(2019, 1, 1),
+            new_org_id=1,
+            new_profession_id=1,
+            new_location_id=1,
+            new_grade_id=Grade.query.filter_by(value=starting_grade).first().id,
+            new_title="Old job",
+            role_change_id=2,
         )
-        assert test_candidate.roles[0].is_promotion() is expected_outcome
+        test_candidate.new_role(
+            start_date=date(2020, 6, 1),
+            new_org_id=1,
+            new_profession_id=1,
+            new_location_id=1,
+            new_grade_id=Grade.query.filter_by(value=new_grade).first().id,
+            new_title="New job",
+            role_change_id=role_change_id,
+        )
+        assert test_candidate.current_role().is_promotion() is expected_outcome

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -191,16 +191,20 @@ class TestDeltaOfferPromotionReport:
 
 
 class TestDetailedPromotionReport:
-    @pytest.mark.parametrize("intake_year", (2017, 2018, 2019))
+    @pytest.mark.parametrize("intake_year", (2018, 2019, 2020))
     @pytest.mark.parametrize("role_change_type", (1, 2, 3))
     @freeze_time(date(2020, 3, 1))
     def test_get_data(
-        self, role_change_type, detailed_candidate, intake_year, test_session
+        self,
+        role_change_type,
+        test_candidate_applied_and_promoted,
+        intake_year,
+        test_session,
     ):
         report = DetailedReport(intake_year, "FLS", role_change_type)
         if (
-            intake_year == 2019 and role_change_type == 1
-        ):  # 1 is a substantive promotion
+            intake_year == 2019 and role_change_type == 2
+        ):  # 2 is a substantive promotion
             assert report.get_data()[0] == [
                 "Testy Candidate",
                 "test.candidate@numberten.gov.uk",
@@ -211,7 +215,7 @@ class TestDetailedPromotionReport:
                 "Director (SCS2)",
                 "Stargate-1",
                 "Department of Fun",
-                date(2018, 9, 1),
+                date(2017, 9, 1),
                 "Admin Assistant (AA)",
                 True,
                 "Terran",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -206,7 +206,7 @@ def test_check_details(
         }
         sess["candidate-id"] = test_candidate.id
     test_client.post("/update/check-your-answers")
-    latest_role: Role = test_candidate.roles.order_by(Role.id.desc()).first()
+    latest_role: Role = test_candidate.current_role()
     assert "Organisation 1" == Organisation.query.get(latest_role.organisation_id).name
     assert "Senior dev" == latest_role.role_name
     assert "substantive" == latest_role.role_change.value

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -212,8 +212,11 @@ def test_check_details(
     assert "substantive" == latest_role.role_change.value
     assert "changed_address@gov.uk" == test_candidate.email_address
 
-    assert len(RoleChangeEvent.query.all()) == 1
-    role_change_event: RoleChangeEvent = RoleChangeEvent.query.first()
+    assert len(RoleChangeEvent.query.all()) == 2
+    # One RoleChangeEvent when candidate joined, and another when this data is POSTed
+    role_change_event: RoleChangeEvent = RoleChangeEvent.query.order_by(
+        RoleChangeEvent.id.desc()
+    ).first()
     assert role_change_event.new_role_id == latest_role.id
     assert role_change_event.role_change_date == date(2019, 1, 1)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -209,7 +209,6 @@ def test_check_details(
     latest_role: Role = test_candidate.current_role()
     assert "Organisation 1" == Organisation.query.get(latest_role.organisation_id).name
     assert "Senior dev" == latest_role.role_name
-    assert "substantive" == latest_role.role_change.value
     assert "changed_address@gov.uk" == test_candidate.email_address
 
     assert len(RoleChangeEvent.query.all()) == 2
@@ -219,6 +218,7 @@ def test_check_details(
     ).first()
     assert role_change_event.new_role_id == latest_role.id
     assert role_change_event.role_change_date == date(2019, 1, 1)
+    assert role_change_event.role_change.value == "substantive"
 
 
 class TestAuthentication:

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -36,7 +36,7 @@ class TestUpload:
         assert len(candidate.roles.all()) == 2
         assert candidate.sexuality.value == "Bisexual"
         assert candidate.current_grade().value == "Grade 6 (or equivalent)"
-        assert candidate.roles[0].date_started == date(2019, 1, 1)
+        assert candidate.current_role().date_started() == date(2019, 1, 1)
         assert (
             candidate.most_recent_application().aspirational_grade.value
             == "SCS2 – Director"


### PR DESCRIPTION
Only 23 extra lines here, and I've taken out a giant chunk of really horrible twisty logic to make the codebase significantly cleaner. The aim following this PR is to drop some fields from the database :scream: because I've moved them into a much neater RoleChangeEvent table.

Broadly speaking, Roles are now attached in time through RoleChangeEvents. Under the hood I've moved logic around but I haven't had to radically change anything that didn't deserve it - for example, I've really improved the way I set up tests.